### PR TITLE
Solve #30 - Redundant hint messages

### DIFF
--- a/scripts/choosenim-unix-init.sh
+++ b/scripts/choosenim-unix-init.sh
@@ -45,7 +45,7 @@ install() {
   fi
 
   # Install Nim from stable channel.
-  "/$temp_prefix/$filename" stable < /dev/tty
+  "/$temp_prefix/$filename" --firstInstall stable < /dev/tty
 
   # Copy choosenim binary to Nimble bin.
   local nimbleBinDir=`"$temp_prefix/$filename" --getNimbleBin`

--- a/src/choosenim/cliparams.nim
+++ b/src/choosenim/cliparams.nim
@@ -57,8 +57,7 @@ Options:
                         installed. Default: ~/.choosenim.
   --nimbleDir:<dir>     Specify the Nimble directory where binaries will be
                         placed. Default: ~/.nimble.
-  --firstInstall        Specify user friendly and less redundant
-                        messages. Used by install script.
+  --firstInstall        Used by install script.
 """
 
 proc command*(params: CliParams): string =

--- a/src/choosenim/cliparams.nim
+++ b/src/choosenim/cliparams.nim
@@ -9,6 +9,7 @@ type
   CliParams* = ref object
     commands*: seq[string]
     choosenimDir*: string
+    firstInstall*: bool
     nimbleOptions*: Options
 
 let doc = """
@@ -56,6 +57,10 @@ Options:
                         installed. Default: ~/.choosenim.
   --nimbleDir:<dir>     Specify the Nimble directory where binaries will be
                         placed. Default: ~/.nimble.
+  --firstInstall       Specify you are trying to install Nim for the first
+                        time. This option supports user friendly messages to
+                        understand how choosenim is working, and less redundant
+                        messages.
 """
 
 proc command*(params: CliParams): string =
@@ -140,6 +145,7 @@ proc getCliParams*(proxyExeMode = false): CliParams =
       of "nocolor": setShowColor(false)
       of "choosenimdir": result.choosenimDir = val
       of "nimbledir": result.nimbleOptions.nimbleDir = val
+      of "firstinstall": result.firstInstall = true
       else:
         if not proxyExeMode:
           raise newException(ChooseNimError, "Unknown flag: --" & key)

--- a/src/choosenim/cliparams.nim
+++ b/src/choosenim/cliparams.nim
@@ -57,10 +57,8 @@ Options:
                         installed. Default: ~/.choosenim.
   --nimbleDir:<dir>     Specify the Nimble directory where binaries will be
                         placed. Default: ~/.nimble.
-  --firstInstall       Specify you are trying to install Nim for the first
-                        time. This option supports user friendly messages to
-                        understand how choosenim is working, and less redundant
-                        messages.
+  --firstInstall        Specify user friendly and less redundant
+                        messages. Used by install script.
 """
 
 proc command*(params: CliParams): string =

--- a/src/choosenim/switcher.nim
+++ b/src/choosenim/switcher.nim
@@ -110,11 +110,12 @@ proc writeProxy(bin: string, params: CliParams) =
 
   # Check whether this is in the user's PATH.
   let fromPATH = findExe(bin)
-  # If the binary does not exists in the binary directory, and the option
-  # firstInstall is not set, display an hint to indicate the solution.
-  if fromPATH == "" and not params.firstInstall:
-    display("Hint:", "Binary '$1' isn't in your PATH. Add '$2' to your PATH." %
-            [bin, params.getBinDir()], Warning, HighPriority)
+  if fromPATH == "":
+    # If the binary does not exists in the bin directory, and the option
+    # firstInstall is not set, display an hint to indicate the solution.
+    if not params.firstInstall:
+      display("Hint:", "Binary '$1' isn't in your PATH. Add '$2' to your PATH." %
+              [bin, params.getBinDir()], Warning, HighPriority)
   elif fromPATH != proxyPath:
     display("Warning:", "Binary '$1' is shadowed by '$2'." %
             [bin, fromPATH], Warning, HighPriority)

--- a/src/choosenim/switcher.nim
+++ b/src/choosenim/switcher.nim
@@ -110,13 +110,10 @@ proc writeProxy(bin: string, params: CliParams) =
 
   # Check whether this is in the user's PATH.
   let fromPATH = findExe(bin)
-  if fromPATH == "":
-    # If the binary does not exists in the bin directory, and the option
-    # firstInstall is not set, display an hint to indicate the solution.
-    if not params.firstInstall:
+  if fromPATH == "" and not params.firstInstall:
       display("Hint:", "Binary '$1' isn't in your PATH. Add '$2' to your PATH." %
               [bin, params.getBinDir()], Warning, HighPriority)
-  elif fromPATH != proxyPath:
+  elif fromPATH != "" and fromPATH != proxyPath:
     display("Warning:", "Binary '$1' is shadowed by '$2'." %
             [bin, fromPATH], Warning, HighPriority)
     display("Hint:", "Ensure that '$1' is before '$2' in the PATH env var." %

--- a/src/choosenim/switcher.nim
+++ b/src/choosenim/switcher.nim
@@ -110,6 +110,8 @@ proc writeProxy(bin: string, params: CliParams) =
 
   # Check whether this is in the user's PATH.
   let fromPATH = findExe(bin)
+  # If the binary does not exists in the binary directory, and the option
+  # firstInstall is not set, display an hint to indicate the solution.
   if fromPATH == "" and not params.firstInstall:
     display("Hint:", "Binary '$1' isn't in your PATH. Add '$2' to your PATH." %
             [bin, params.getBinDir()], Warning, HighPriority)

--- a/src/choosenim/switcher.nim
+++ b/src/choosenim/switcher.nim
@@ -110,7 +110,7 @@ proc writeProxy(bin: string, params: CliParams) =
 
   # Check whether this is in the user's PATH.
   let fromPATH = findExe(bin)
-  if fromPATH == "":
+  if fromPATH == "" and not params.firstInstall:
     display("Hint:", "Binary '$1' isn't in your PATH. Add '$2' to your PATH." %
             [bin, params.getBinDir()], Warning, HighPriority)
   elif fromPATH != proxyPath:


### PR DESCRIPTION
Add a simple change to avoid redundant hint message, installing Nim for the first time.
To do that, I added a new switch called 'firstInstall', that will enable a boolean value in `CliParams` (cliparams.nim).
This boolean value will be check in `switcher.nim`. If the condition is verified, the program will not print out hints about non-existing binaries in local path.

Simple resolution for #30 