### PR TITLE
Remove / prefix when calling choosenim binary

### DIFF
--- a/scripts/choosenim-unix-init.sh
+++ b/scripts/choosenim-unix-init.sh
@@ -49,10 +49,10 @@ install() {
     fi
 
     # Install Nim from desired channel.
-    "/$temp_prefix/$filename" $CHOOSE_VERSION --firstInstall < /dev/tty
+    "$temp_prefix/$filename" $CHOOSE_VERSION --firstInstall < /dev/tty
   else
     # TODO: Use the -y switch when choosenim gets support for it.
-    yes | "/$temp_prefix/$filename" $CHOOSE_VERSION --firstInstall
+    yes | "$temp_prefix/$filename" $CHOOSE_VERSION --firstInstall
   fi
 
   # Copy choosenim binary to Nimble bin.


### PR DESCRIPTION
`$temp_prefix` defaults to `/tmp` (or uses the `$TMPDIR` environment variable). Prepending the `/` prefix results in trying to call a path like `//tmp/choosenim-0.3.2_linux_amd64`.