### PR TITLE
Improved handling of proxy environment variables

### DIFF
--- a/src/choosenim/download.nim
+++ b/src/choosenim/download.nim
@@ -149,6 +149,10 @@ proc getProxy*(): Proxy =
       url = getEnv("http_proxy")
     elif existsEnv("https_proxy"):
       url = getEnv("https_proxy")
+    elif existsEnv("HTTP_PROXY"):
+      url = getEnv("HTTP_PROXY")
+    elif existsEnv("HTTPS_PROXY"):
+      url = getEnv("HTTPS_PROXY")
   except ValueError:
     display("Warning:", "Unable to parse proxy from environment: " &
         getCurrentExceptionMsg(), Warning, HighPriority)


### PR DESCRIPTION
Environment variables only use capital letters and `_`, `http_proxy` is not enough.