### PR TITLE
[Feature Addition] Add force update switch `--force`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,6 @@ src/choosenim/proxyexe
 *.exe
 
 tests/nimcache
-tests/chooseNimDir
+tests/choosenimDir
 tests/nimbleDir
 tests/tester
-

--- a/readme.md
+++ b/readme.md
@@ -63,18 +63,19 @@ assuming that 0.16.0 was selected.
 
 Due to lack of official binaries for most platforms, ``choosenim`` downloads
 the source and builds it by default. This operation is only performed once
-when a new version is selected.
+when a new version is selected, unless the ``--force`` switch is utilized, in
+which case ``choosenim`` will delete and re-download the toolchain.
 
 In the future ``choosenim`` will download binaries whenever they are available.
 
 ## Dependencies
 
-|            |           Windows             |        Linux       |        macOS (*)      |
-|------------|:-----------------------------:|:------------------:|:---------------------:|
-| C compiler | *Downloaded automatically*    |      gcc/clang     |      gcc/clang        |
-| OpenSSL    |          >= 1.0.2k            |      >= 1.0.2k     |         N/A           |
-| curl       |             N/A               |         N/A        | Any recent version    |
-| zlib       | *Statically linked in binary* | Any recent version | Any recent version    |
+|            | Windows                       | Linux              | macOS (*)          |
+| ---------- | :---------------------------: | :----------------: | :----------------: |
+| C compiler | *Downloaded automatically*    | gcc/clang          | gcc/clang          |
+| OpenSSL    | >= 1.0.2k                     | >= 1.0.2k          | N/A                |
+| curl       | N/A                           | N/A                | Any recent version |
+| zlib       | *Statically linked in binary* | Any recent version | Any recent version |
 
 \* Many macOS dependencies should already be installed. You may need to install
    a C compiler however.

--- a/src/choosenim.nim
+++ b/src/choosenim.nim
@@ -137,8 +137,8 @@ proc update(params: CliParams) =
   # Retrieve the current version for the specified channel.
   let version = getChannelVersion(channel, params, live=true).newVersion
 
-  # Ensure that the version isn't already installed.
-  if not canUpdate(version, params):
+  # Ensure that the version isn't already installed, unless `--force` was used.
+  if not (canUpdate(version, params) or params.forceUpdate):
     display("Info:", "Already up to date at version " & $version,
             Success, HighPriority)
     if getSelectedVersion(params) != version:

--- a/src/choosenim/cliparams.nim
+++ b/src/choosenim/cliparams.nim
@@ -11,6 +11,7 @@ type
     commands*: seq[string]
     choosenimDir*: string
     firstInstall*: bool
+    forceUpdate*: bool
     nimbleOptions*: Options
     analytics*: AsyncAnalytics
     pendingReports*: int ## Count of pending telemetry reports.
@@ -58,6 +59,7 @@ Options:
   --verbose             Show low (and higher) priority output.
   --debug               Show debug (and higher) priority output.
   --noColor             Don't colorise output.
+  --force               Delete and re-create chosen version/channel.
 
   --choosenimDir:<dir>  Specify the directory where toolchains should be
                         installed. Default: ~/.choosenim.
@@ -157,6 +159,7 @@ proc parseCliParams*(params: var CliParams, proxyExeMode = false) =
       of "verbose": setVerbosity(LowPriority)
       of "debug": setVerbosity(DebugPriority)
       of "nocolor": setShowColor(false)
+      of "force": params.forceUpdate = true
       of "choosenimdir": params.choosenimDir = val
       of "nimbledir": params.nimbleOptions.nimbleDir = val
       of "firstinstall": params.firstInstall = true


### PR DESCRIPTION
This PR adds a switch `--force` (Issue #88) which causes `choosenim` to always delete and re-download, rebuild, etc. the entire toolchain for whichever version/channel is to be updated. This does nothing for any command other than `update`.

**Example:** `choosenim update stable --force`

_I also fixed a minor `.gitignore` capitalization mistake._