### PR TITLE
Issue #96 - Add analytics proxy support

### DIFF
--- a/choosenim.nimble
+++ b/choosenim.nimble
@@ -15,7 +15,7 @@ skipExt = @["nim"]
 
 requires "nim >= 0.16.1", "nimble >= 0.8.5", "untar >= 0.1.0"
 requires "libcurl >= 1.0.0"
-requires "analytics >= 0.1.0"
+requires "analytics >= 0.1.1"
 requires "osinfo >= 0.2.0"
 
 task test, "Run the choosenim tester!":

--- a/src/choosenim/download.nim
+++ b/src/choosenim/download.nim
@@ -1,10 +1,10 @@
-import httpclient, strutils, os, terminal, times, math, uri
+import httpclient, strutils, os, terminal, times, math
 
 import nimblepkg/[version, cli]
 when defined(curl):
   import libcurl except Version
 
-import cliparams, common, telemetry
+import cliparams, common, telemetry, utils
 
 const
   githubUrl = "https://github.com/nim-lang/Nim/archive/$1.tar.gz"
@@ -140,29 +140,6 @@ when defined(curl):
     if responseCode != 200:
       raise newException(HTTPRequestError,
              "Expected HTTP code $1 got $2" % [$200, $responseCode])
-
-proc getProxy*(): Proxy =
-  ## Returns ``nil`` if no proxy is specified.
-  var url = ""
-  try:
-    if existsEnv("http_proxy"):
-      url = getEnv("http_proxy")
-    elif existsEnv("https_proxy"):
-      url = getEnv("https_proxy")
-  except ValueError:
-    display("Warning:", "Unable to parse proxy from environment: " &
-        getCurrentExceptionMsg(), Warning, HighPriority)
-
-  if url.len > 0:
-    var parsed = parseUri(url)
-    if parsed.scheme.len == 0 or parsed.hostname.len == 0:
-      parsed = parseUri("http://" & url)
-    let auth =
-      if parsed.username.len > 0: parsed.username & ":" & parsed.password
-      else: ""
-    return newProxy($parsed, auth)
-  else:
-    return nil
 
 proc downloadFileNim(url, outputPath: string) =
   var client = newHttpClient(proxy = getProxy())

--- a/src/choosenim/telemetry.nim
+++ b/src/choosenim/telemetry.nim
@@ -10,7 +10,7 @@ when defined(windows):
 else:
   import osinfo/posix
 
-import cliparams, common
+import cliparams, common, utils
 
 type
   EventCategory* = enum
@@ -118,7 +118,7 @@ proc loadAnalytics*(params: CliParams): bool =
     return false
 
   params.analytics = newAsyncAnalytics("UA-105812497-1", clientID, "choosenim",
-                                       chooseNimVersion)
+                                       chooseNimVersion, proxy = getProxy())
 
   # Report OS info only once.
   if prompted:

--- a/src/choosenim/utils.nim
+++ b/src/choosenim/utils.nim
@@ -1,4 +1,4 @@
-import os, strutils, osproc
+import httpclient, os, strutils, osproc, uri
 
 import nimblepkg/[cli, tools, version]
 import untar
@@ -50,3 +50,26 @@ proc extract*(path: string, extractDir: string) =
   except Exception as exc:
     raise newException(ChooseNimError, "Unable to extract. Error was '$1'." %
                        exc.msg)
+
+proc getProxy*(): Proxy =
+  ## Returns ``nil`` if no proxy is specified.
+  var url = ""
+  try:
+    if existsEnv("http_proxy"):
+      url = getEnv("http_proxy")
+    elif existsEnv("https_proxy"):
+      url = getEnv("https_proxy")
+  except ValueError:
+    display("Warning:", "Unable to parse proxy from environment: " &
+        getCurrentExceptionMsg(), Warning, HighPriority)
+
+  if url.len > 0:
+    var parsed = parseUri(url)
+    if parsed.scheme.len == 0 or parsed.hostname.len == 0:
+      parsed = parseUri("http://" & url)
+    let auth =
+      if parsed.username.len > 0: parsed.username & ":" & parsed.password
+      else: ""
+    return newProxy($parsed, auth)
+  else:
+    return nil


### PR DESCRIPTION
- Move `getProxy()` to utils.nim since download.nim and telemetry.nim both need it
- Sent proxy info to `newAsyncAnalytics()`