### PR TITLE
adding command `versions` to list installable versions of nim

### DIFF
--- a/src/choosenim.nim
+++ b/src/choosenim.nim
@@ -211,24 +211,36 @@ proc list(params: CliParams) =
     else: getAvailableVersions(params)
 
   #[ Display version information,now that it has been collected ]#
+  proc isActiveTag(params: CliParams, version: string): string =
+    let tag = if version == currentVersion: "*"
+              else: " "
+    return tag
+  proc isLatestTag(params: CliParams, version: string): string =
+    let tag = if isLatestVersion(params, version): " (latest)"
+            else: ""
+    return tag
+  proc canUpdateTag(params: CliParams, channel: string): string =
+    let version = getChannelVersion(channel, params, live = true)
+    let channelVersion = parseVersion(version)
+    let tag = if canUpdate(channelVersion, params): " (update available!)"
+              else: ""
+    return tag
 
-  # display the currently selected version info
-  display("Current:", "", priority = HighPriority)
-  display("  Version:", currentVersion & isLatestTag(params, currentVersion), priority = HighPriority)
+
   if currentChannel.len > 0:
-    display("  Channel:", currentChannel, priority = HighPriority)
-  echo ""
+    display("Channel:", currentChannel & canUpdateTag(params, currentChannel), priority = HighPriority)
+    echo ""
 
   # local versions
   display("Installed:", " ", priority = HighPriority)
   for version in localVersions:
-    display("", version & isLatestTag(params, version), priority = HighPriority)
+    display(isActiveTag(params, version), version & isLatestTag(params, version), priority = HighPriority)
   for version in specialVersions:
-    display("", version, priority = HighPriority)
+    display(isActiveTag(params, version), version, priority = HighPriority)
   echo ""
 
   # if the "--installed" flag was passed, don't display remote versions as we didn't fetch data for them.
-  if not params.onlyInstalled:
+  if (not params.onlyInstalled):
     display("Available:", " ", priority = HighPriority)
     for version in remoteVersions:
       if not (version in localVersions):

--- a/src/choosenim.nim
+++ b/src/choosenim.nim
@@ -9,26 +9,6 @@ from nimblepkg/packageinfo import getNameVersion
 import choosenim/[download, builder, switcher, common, cliparams, versions]
 import choosenim/[utils, channel, telemetry]
 
-proc parseVersion(versionStr: string): Version =
-  if versionStr[0] notin {'#', '\0'} + Digits:
-    let msg = "Invalid version, path or unknown channel. " &
-              "Try 0.16.0, #head, #commitHash, or stable. " &
-              "See --help for more examples."
-    raise newException(ChooseNimError, msg)
-
-  let parts = versionStr.split(".")
-  if parts.len >= 3 and parts[2].parseInt() mod 2 != 0:
-    let msg = ("Version $# is a development version of Nim. This means " &
-              "it hasn't been released so you cannot install it this " &
-              "way. All unreleased versions of Nim " &
-              "have an odd patch number in their version.") % versionStr
-    let exc = newException(ChooseNimError, msg)
-    exc.hint = "If you want to install the development version then run " &
-               "`choosenim devel`."
-    raise exc
-
-  result = newVersion(versionStr)
-
 proc installVersion(version: Version, params: CliParams) =
   # Install the requested version.
   let path = download(version, params)
@@ -220,7 +200,7 @@ proc versions(params: CliParams) =
             else: ""
     return tag
   proc canUpdateTag(params: CliParams, channel: string): string =
-    let version = getChannelVersion(channel, params, live = true)
+    let version = getChannelVersion(channel, params, live = (not params.onlyInstalled))
     let channelVersion = parseVersion(version)
     let tag = if canUpdate(channelVersion, params): " (update available!)"
               else: ""

--- a/src/choosenim.nim
+++ b/src/choosenim.nim
@@ -196,7 +196,7 @@ proc show(params: CliParams) =
       else:
         display("", ver, priority = HighPriority)
 
-proc list(params: CliParams) =
+proc versions(params: CliParams) =
   let currentChannel = getCurrentChannel(params)
   let currentVersion = getCurrentVersion(params)
 
@@ -256,8 +256,8 @@ proc performAction(params: CliParams) =
     update(params)
   of "show":
     show(params)
-  of "list":
-    list(params)
+  of "versions":
+    versions(params)
   else:
     choose(params)
 

--- a/src/choosenim.nim
+++ b/src/choosenim.nim
@@ -214,7 +214,10 @@ proc versions(params: CliParams) =
   # local versions
   display("Installed:", " ", priority = HighPriority)
   for version in localVersions:
-    display(isActiveTag(params, version), version & isLatestTag(params, version), priority = HighPriority)
+    let activeDisplay =
+      if version == currentVersion: Success
+      else: Message
+    display(isActiveTag(params, version), version & isLatestTag(params, version), activeDisplay, priority = HighPriority)
   for version in specialVersions:
     display(isActiveTag(params, version), version, priority = HighPriority)
   echo ""

--- a/src/choosenim.nim
+++ b/src/choosenim.nim
@@ -180,32 +180,37 @@ proc versions(params: CliParams) =
   let currentChannel = getCurrentChannel(params)
   let currentVersion = getCurrentVersion(params)
 
-  let specialVersions: seq[string] = getSpecialVersions(params)
-  let localVersions: seq[string] = getInstalledVersions(params)
+  let specialVersions = getSpecialVersions(params)
+  let localVersions = getInstalledVersions(params)
 
-  let latestVersion: string =
-    if params.onlyInstalled: ""
+  let latestVersion =
+    if params.onlyInstalled: newVersion("")
     else: getLatestVersion(params)
-  let remoteVersions: seq[string] =
+  let remoteVersions =
     if params.onlyInstalled: @[]
     else: getAvailableVersions(params)
 
-  #[ Display version information,now that it has been collected ]#
-  proc isActiveTag(params: CliParams, version: string): string =
-    let tag = if version == currentVersion: "*"
-              else: " "
+  proc isActiveTag(params: CliParams, version: Version): string =
+    let tag =
+      if version == currentVersion: "*"
+      else: " " # must have non-zero length, or won't be displayed
     return tag
-  proc isLatestTag(params: CliParams, version: string): string =
-    let tag = if isLatestVersion(params, version): " (latest)"
-            else: ""
+
+  proc isLatestTag(params: CliParams, version: Version): string =
+    let tag =
+      if isLatestVersion(params, version): " (latest)"
+      else: ""
     return tag
+
   proc canUpdateTag(params: CliParams, channel: string): string =
     let version = getChannelVersion(channel, params, live = (not params.onlyInstalled))
     let channelVersion = parseVersion(version)
-    let tag = if canUpdate(channelVersion, params): " (update available!)"
-              else: ""
+    let tag =
+      if canUpdate(channelVersion, params): " (update available!)"
+      else: ""
     return tag
 
+  #[ Display version information,now that it has been collected ]#
 
   if currentChannel.len > 0:
     display("Channel:", currentChannel & canUpdateTag(params, currentChannel), priority = HighPriority)
@@ -217,9 +222,9 @@ proc versions(params: CliParams) =
     let activeDisplay =
       if version == currentVersion: Success
       else: Message
-    display(isActiveTag(params, version), version & isLatestTag(params, version), activeDisplay, priority = HighPriority)
+    display(isActiveTag(params, version), $version & isLatestTag(params, version), activeDisplay, priority = HighPriority)
   for version in specialVersions:
-    display(isActiveTag(params, version), version, priority = HighPriority)
+    display(isActiveTag(params, version), $version, priority = HighPriority)
   echo ""
 
   # if the "--installed" flag was passed, don't display remote versions as we didn't fetch data for them.
@@ -227,7 +232,7 @@ proc versions(params: CliParams) =
     display("Available:", " ", priority = HighPriority)
     for version in remoteVersions:
       if not (version in localVersions):
-        display("", version & isLatestTag(params, version), priority = HighPriority)
+        display("", $version & isLatestTag(params, version), priority = HighPriority)
     echo ""
 
 proc performAction(params: CliParams) =

--- a/src/choosenim/cliparams.nim
+++ b/src/choosenim/cliparams.nim
@@ -9,6 +9,7 @@ import common
 type
   CliParams* = ref object
     commands*: seq[string]
+    onlyInstalled*: bool
     choosenimDir*: string
     firstInstall*: bool
     nimbleOptions*: Options
@@ -37,6 +38,8 @@ Example:
     Selects the specified Nim installation.
   choosenim update stable
     Updates the version installed on the stable release channel.
+  choosenim list [--installed]
+    Lists the available versions of Nim that choosenim has access to.
 
 Channels:
   stable
@@ -50,6 +53,9 @@ Commands:
                                  version or channel.
   show                           Displays the selected version and channel.
   update    self                 Updates choosenim itself.
+  list      [--installed]        Lists available versions of Nim, passing
+                                 `--installed` only displays versions that
+                                 are installed locally (no network requests).
 
 Options:
   -h --help             Show this output.
@@ -161,6 +167,7 @@ proc parseCliParams*(params: var CliParams, proxyExeMode = false) =
       of "nimbledir": params.nimbleOptions.nimbleDir = val
       of "firstinstall": params.firstInstall = true
       of "y", "yes": params.nimbleOptions.forcePrompts = forcePromptYes
+      of "installed": params.onlyInstalled = true
       else:
         if not proxyExeMode:
           raise newException(ChooseNimError, "Unknown flag: --" & key)

--- a/src/choosenim/cliparams.nim
+++ b/src/choosenim/cliparams.nim
@@ -38,7 +38,7 @@ Example:
     Selects the specified Nim installation.
   choosenim update stable
     Updates the version installed on the stable release channel.
-  choosenim list [--installed]
+  choosenim versions [--installed]
     Lists the available versions of Nim that choosenim has access to.
 
 Channels:
@@ -53,7 +53,7 @@ Commands:
                                  version or channel.
   show                           Displays the selected version and channel.
   update    self                 Updates choosenim itself.
-  list      [--installed]        Lists available versions of Nim, passing
+  versions  [--installed]        Lists available versions of Nim, passing
                                  `--installed` only displays versions that
                                  are installed locally (no network requests).
 

--- a/src/choosenim/download.nim
+++ b/src/choosenim/download.nim
@@ -313,14 +313,17 @@ proc retrieveUrl*(url: string): string =
     var client = newHttpClient(proxy = getProxy())
     return client.getContent(url)
 
-proc getOfficialReleases*(params: CliParams): seq[string] =
+proc getOfficialReleases*(params: CliParams): seq[Version] =
   let rawContents = retrieveUrl(githubTagReleasesUrl)
   let parsedContents = parseJson(rawContents)
+  let cutOffVersion = newVersion("0.16.0")
 
-  var releases: seq[string] = @[]
+  var releases: seq[Version] = @[]
   for release in parsedContents:
-    let name = release["name"].getStr()
-    releases.add(name)
+    let name = release["name"].getStr().strip(true, false, {'v'})
+    let version = name.newVersion
+    if cutOffVersion <= version:
+      releases.add(version)
   return releases
 
 when isMainModule:

--- a/src/choosenim/download.nim
+++ b/src/choosenim/download.nim
@@ -4,7 +4,7 @@ import nimblepkg/[version, cli]
 when defined(curl):
   import libcurl except Version
 
-import cliparams, common, switcher, telemetry, utils, versions
+import cliparams, common, switcher, telemetry, utils
 
 const
   githubTagReleasesUrl = "https://api.github.com/repos/nim-lang/Nim/tags"
@@ -319,7 +319,7 @@ proc getOfficialReleases*(params: CliParams): seq[string] =
 
   var releases: seq[string] = @[]
   for release in parsedContents:
-    let name = normalizeVersion(release["name"].getStr())
+    let name = release["name"].getStr()
     releases.add(name)
   return releases
 

--- a/src/choosenim/utils.nim
+++ b/src/choosenim/utils.nim
@@ -5,6 +5,26 @@ import untar
 
 import switcher, cliparams, common
 
+proc parseVersion*(versionStr: string): Version =
+  if versionStr[0] notin {'#', '\0'} + Digits:
+    let msg = "Invalid version, path or unknown channel. " &
+              "Try 0.16.0, #head, #commitHash, or stable. " &
+              "See --help for more examples."
+    raise newException(ChooseNimError, msg)
+
+  let parts = versionStr.split(".")
+  if parts.len >= 3 and parts[2].parseInt() mod 2 != 0:
+    let msg = ("Version $# is a development version of Nim. This means " &
+              "it hasn't been released so you cannot install it this " &
+              "way. All unreleased versions of Nim " &
+              "have an odd patch number in their version.") % versionStr
+    let exc = newException(ChooseNimError, msg)
+    exc.hint = "If you want to install the development version then run " &
+               "`choosenim devel`."
+    raise exc
+
+  result = newVersion(versionStr)
+
 proc doCmdRaw*(cmd: string) =
   # To keep output in sequence
   stdout.flushFile()

--- a/src/choosenim/versions.nim
+++ b/src/choosenim/versions.nim
@@ -1,0 +1,68 @@
+
+import os, strutils, algorithm, sequtils
+
+import nimblepkg/version
+from nimblepkg/packageinfo import getNameVersion
+
+import download, cliparams, channel, switcher
+
+proc normalizeVersion*(version: string): string =
+  if not (version in @["#devel", "#head"]):
+    return version.strip(true, false, {'#', 'v'})
+  else:
+    return version
+
+proc getLocalVersions(params: CliParams): seq[string] =
+  let path = getSelectedPath(params)
+  
+  var localVersions: seq[string] = @[] 
+  # check for the locally installed versions of Nim,
+  for path in walkDirs(params.getInstallDir() & "/*"):
+    let (_, version) = getNameVersion(path)
+    let displayVersion = version.normalizeVersion()
+    localVersions.add(displayVersion)
+  localVersions.sort(system.cmp[string], SortOrder.Descending)
+  return localVersions
+
+proc getSpecialVersions*(params: CliParams): seq[string] =
+  var specialVersions = getLocalVersions(params)
+  specialVersions.keepItIf(it.endsWith("#devel") or it.endsWith("#head"))
+  return specialVersions
+
+proc getInstalledVersions*(params: CliParams): seq[string] =
+  var installedVersions = getLocalVersions(params)
+  installedVersions.keepItIf(not (it.endsWith("#devel") or it.endsWith("#head")))
+  return installedVersions
+
+proc getAvailableVersions*(params: CliParams): seq[string] =
+  let releases = getOfficialReleases(params)
+  return releases
+
+proc getCurrentVersion*(params: CliParams): string =
+  let path = getSelectedPath(params)
+  let (currentName, currentVersion) = getNameVersion(path)  
+  return currentVersion.normalizeVersion()
+
+proc getLatestVersion*(params: CliParams): string =
+  let latest = getChannelVersion("stable", params).normalizeVersion()
+  return latest
+  
+proc isLatestVersion*(params: CliParams, version: string): bool =
+  let isLatest = (getLatestVersion(params) == version)
+  return isLatest
+  
+proc isLatestTag*(params: CliParams, version: string): string =
+  let tag = if isLatestVersion(params, version): " (latest)"
+            else: ""
+  return tag
+
+proc isInstalled*(params: CliParams, version: string): bool =
+  let isInstalled = (version in getLocalVersions(params))
+  return isInstalled
+
+proc isInstalledTag*(params: CliParams, version: string): string =
+  let tag = if isInstalled(params, version): " (installed)"
+            else: ""
+  return tag
+
+  

--- a/src/choosenim/versions.nim
+++ b/src/choosenim/versions.nim
@@ -4,7 +4,7 @@ import os, strutils, algorithm, sequtils
 import nimblepkg/version
 from nimblepkg/packageinfo import getNameVersion
 
-import download, cliparams, channel, switcher
+import download, cliparams, channel, switcher, utils
 
 proc normalizeVersion*(version: string): string =
   if not (version in @["#devel", "#head"]):
@@ -19,8 +19,9 @@ proc getLocalVersions(params: CliParams): seq[string] =
   # check for the locally installed versions of Nim,
   for path in walkDirs(params.getInstallDir() & "/*"):
     let (_, version) = getNameVersion(path)
-    let displayVersion = version.normalizeVersion()
-    localVersions.add(displayVersion)
+    if isVersionInstalled(params, parseVersion(version)):
+      let displayVersion = version.normalizeVersion()
+      localVersions.add(displayVersion)
   localVersions.sort(system.cmp[string], SortOrder.Descending)
   return localVersions
 

--- a/src/choosenim/versions.nim
+++ b/src/choosenim/versions.nim
@@ -35,7 +35,8 @@ proc getInstalledVersions*(params: CliParams): seq[string] =
   return installedVersions
 
 proc getAvailableVersions*(params: CliParams): seq[string] =
-  let releases = getOfficialReleases(params)
+  var releases = getOfficialReleases(params)
+  releases.applyIt(it.normalizeVersion)
   return releases
 
 proc getCurrentVersion*(params: CliParams): string =
@@ -50,19 +51,3 @@ proc getLatestVersion*(params: CliParams): string =
 proc isLatestVersion*(params: CliParams, version: string): bool =
   let isLatest = (getLatestVersion(params) == version)
   return isLatest
-  
-proc isLatestTag*(params: CliParams, version: string): string =
-  let tag = if isLatestVersion(params, version): " (latest)"
-            else: ""
-  return tag
-
-proc isInstalled*(params: CliParams, version: string): bool =
-  let isInstalled = (version in getLocalVersions(params))
-  return isInstalled
-
-proc isInstalledTag*(params: CliParams, version: string): string =
-  let tag = if isInstalled(params, version): " (installed)"
-            else: ""
-  return tag
-
-  

--- a/src/choosenim/versions.nim
+++ b/src/choosenim/versions.nim
@@ -46,7 +46,8 @@ proc getCurrentVersion*(params: CliParams): string =
   return currentVersion.normalizeVersion()
 
 proc getLatestVersion*(params: CliParams): string =
-  let latest = getChannelVersion("stable", params).normalizeVersion()
+  let channel = getCurrentChannel(params)
+  let latest = getChannelVersion(channel, params).normalizeVersion()
   return latest
   
 proc isLatestVersion*(params: CliParams, version: string): bool =


### PR DESCRIPTION
Overview:
i threw this together today in an attempt fix an outstanding issue i've had (#22), namely: being able to list which versions of Nim can be installed by `choosenim`.

Important Notes:
* Added a new command named `versions`, that takes an optional flag `--installed` which limits displayed output to only versions that are currently installed (avoids performing network requests as well).
* Added new code to query against the github releases of Nim, to give names/numbers to the versions that it was already able to fetch.
* Matched the display style of the "active version" to that shown by the `show` command.
* Added method `normalizeVersion` in `versions.nim` to try to standardize the what version numbers are displayed (removing all prefixed "#" and "v", so it only shows the semver number). I hope this can be removed at some point where a more standard way of displaying the version numbers can be put in place.