### PR TITLE
Fail if compiler missing on posix

### DIFF
--- a/src/choosenim.nim
+++ b/src/choosenim.nim
@@ -36,10 +36,9 @@ proc chooseVersion(version: string, params: CliParams) =
       let path = downloadMingw32(params)
       extract(path, getMingwPath(params))
     else:
-      display("Warning:", "No C compiler found. Nim compiler might fail.",
-              Warning, HighPriority)
-      display("Hint:", "Install clang or gcc using your favourite package manager.",
-              Warning, HighPriority)
+      raise newException(ChooseNimError,
+                         "No C compiler found. Nim compiler requires a C compiler.\n" &
+                         "Install clang or gcc using your favourite package manager.")
 
   # Verify that DLLs (openssl primarily) are installed.
   when defined(windows):


### PR DESCRIPTION
If C compiler is missing on posix, you cannot get gccArch to download the right binary archive of Nim. So then choosenim tries to build Nim which also fails since there's no C compiler.

This is better off as a failure than a warning which fails later anyway.