### PR TITLE
Fix #128 - detect arch on Windows for mingw

### DIFF
--- a/src/choosenim.nim
+++ b/src/choosenim.nim
@@ -35,7 +35,7 @@ proc chooseVersion(version: string, params: CliParams) =
   if params.needsCCInstall():
     when defined(windows):
       # Install MingW.
-      let path = downloadMingw32(params)
+      let path = downloadMingw(params)
       extract(path, getMingwPath(params))
     else:
       raise newException(ChooseNimError,

--- a/src/choosenimpkg/cliparams.nim
+++ b/src/choosenimpkg/cliparams.nim
@@ -113,6 +113,8 @@ proc getCpuArch*(): int =
   if cpuArch != 0:
     return cpuArch
 
+  var
+    failMsg = ""
   when defined(windows):
     let
       archEnv = getEnv("PROCESSOR_ARCHITECTURE")
@@ -125,6 +127,9 @@ proc getCpuArch*(): int =
       result = 64
     elif "86" in archEnv:
       result = 32
+    else:
+      failMsg = "PROCESSOR_ARCHITECTURE = " & archEnv &
+                ", PROCESSOR_ARCHITEW6432 = " & arch6432Env
   else:
     let
       uname = findExe("uname")
@@ -136,9 +141,15 @@ proc getCpuArch*(): int =
           result = 64
         elif "86" in outp:
           result = 32
+        else:
+          failMsg = "uname -m = " & outp
+      else:
+        failMsg = "uname -m failed: " & $errC & "\n" & outp
+    else:
+      failMsg = "uname not found"
 
   # Die if unsupported - better fail than guess
-  doAssert result != 0, "getCpuArch() not implemented"
+  doAssert result != 0, "FATAL: Could not detect your CPI architecture\n" & failMsg
 
   # Only once
   cpuArch = result

--- a/src/choosenimpkg/cliparams.nim
+++ b/src/choosenimpkg/cliparams.nim
@@ -149,15 +149,16 @@ proc getCpuArch*(): int =
       failMsg = "uname not found"
 
   # Die if unsupported - better fail than guess
-  doAssert result != 0, "FATAL: Could not detect your CPI architecture\n" & failMsg
+  if result == 0:
+    raise newException(ChooseNimError,
+      "Fatal: Could not detect your CPI architecture\n" & failMsg)
 
   # Only once
   cpuArch = result
 
 proc getMingwPath*(params: CliParams): string =
-  let
-    arch = getCpuArch()
-  return params.getInstallDir() / "mingw" % $arch
+  let arch = getCpuArch()
+  return params.getInstallDir() / "mingw" & $arch
 
 proc getMingwBin*(params: CliParams): string =
   return getMingwPath(params) / "bin"

--- a/src/choosenimpkg/cliparams.nim
+++ b/src/choosenimpkg/cliparams.nim
@@ -151,7 +151,7 @@ proc getCpuArch*(): int =
   # Die if unsupported - better fail than guess
   if result == 0:
     raise newException(ChooseNimError,
-      "Fatal: Could not detect your CPI architecture\n" & failMsg)
+      "Fatal: Could not detect your CPU architecture\n" & failMsg)
 
   # Only once
   cpuArch = result

--- a/src/choosenimpkg/cliparams.nim
+++ b/src/choosenimpkg/cliparams.nim
@@ -1,8 +1,5 @@
 import parseopt, strutils, os
 
-when not defined(windows):
-  import osproc
-
 import nimblepkg/[cli, options, config]
 import nimblepkg/common as nimble_common
 import analytics

--- a/src/choosenimpkg/download.nim
+++ b/src/choosenimpkg/download.nim
@@ -15,7 +15,7 @@ const
   binaryUrl = "http://nim-lang.org/download/nim-$1$2_x$3" & getBinArchiveFormat()
 
 const # Windows-only
-  mingwUrl = "http://nim-lang.org/download/mingw32.7z"
+  mingwUrl = "http://nim-lang.org/download/mingw$1.7z"
   dllsUrl = "http://nim-lang.org/download/dlls.zip"
 
 const
@@ -269,13 +269,16 @@ proc downloadCSources*(params: CliParams): string =
   downloadFile(csourcesArchiveUrl, outputPath, params)
   return outputPath
 
-proc downloadMingw32*(params: CliParams): string =
+proc downloadMingw*(params: CliParams): string =
+  let
+    arch = getCpuArch()
+    url = mingwUrl % $arch
   var outputPath: string
-  if not needsDownload(params, mingwUrl, outputPath):
+  if not needsDownload(params, url, outputPath):
     return outputPath
 
-  display("Downloading", "C compiler (Mingw32)", priority = HighPriority)
-  downloadFile(mingwUrl, outputPath, params)
+  display("Downloading", "C compiler (Mingw$1)" % $arch, priority = HighPriority)
+  downloadFile(url, outputPath, params)
   return outputPath
 
 proc downloadDLLs*(params: CliParams): string =

--- a/src/choosenimpkg/switcher.nim
+++ b/src/choosenimpkg/switcher.nim
@@ -55,7 +55,10 @@ proc isDefaultCCInPath*(params: CliParams): bool =
 proc needsCCInstall*(params: CliParams): bool =
   ## Determines whether the system needs a C compiler to be installed.
   let inPath = isDefaultCCInPath(params)
-  let inMingwDir = fileExists(params.getMingwBin() / "gcc".addFileExt(ExeExt))
+  let inMingwDir =
+    when defined(windows):
+      fileExists(params.getMingwBin() / "gcc".addFileExt(ExeExt))
+    else: false
   let isInstalled = inPath or inMingwDir
   return not isInstalled
 


### PR DESCRIPTION
Installs mingw32 on 32-bit Windows and mingw64 on 64-bit Windows. This will also work correctly if someone builds a 32-bit version of choosenim and runs it on 64-bit Windows.

@dom96 @Araq