### PR TITLE
CI tests fail after the first time.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,6 @@ install:
   # https://gist.github.com/genotrance/fb53504a4fba88bc5201d3783df5c522
   - curl https://gist.github.com/genotrance/fb53504a4fba88bc5201d3783df5c522/raw/travis.sh -LsSf -o travis.sh
   - source travis.sh
-  - choosenim stable
 
 script:
   - nimble install -y -d

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ install:
   # https://gist.github.com/genotrance/fb53504a4fba88bc5201d3783df5c522
   - curl https://gist.github.com/genotrance/fb53504a4fba88bc5201d3783df5c522/raw/travis.sh -LsSf -o travis.sh
   - source travis.sh
+  - choosenim stable
 
 script:
   - nimble install -y -d

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ env:
 cache:
   directories:
     - "$HOME/.choosenim"
+    - "$HOME/.nimble"
     - "$TRAVIS_BUILD_DIR/git"
 
 install:


### PR DESCRIPTION
@dom96 @genotrance 
https://gist.github.com/genotrance/fb53504a4fba88bc5201d3783df5c522#file-travis-sh
This script check choosenim exist. But, not check nim and nimble.  
`$HOME/.choosenim` is cached, but `$HOME/.nimble` is not cached in .travis.yml.
So the TravisCI test will fail after the first time.
We need add cache nimble dir in .travis.yml, or fix travis.sh .
[fix travis.sh](https://gist.github.com/iranika/ec97e8f0f97c59243c648e14b2f0366e#file-travis-sh)

Which do you like better ? 🤔 