### PR TITLE
Fix #12 - use git to update devel

### DIFF
--- a/src/choosenim.nim
+++ b/src/choosenim.nim
@@ -13,22 +13,29 @@ when defined(windows):
   import choosenimpkg/env
 
 proc installVersion(version: Version, params: CliParams) =
-  # Install the requested version.
-  let path = download(version, params)
-  # Extract the downloaded file.
-  let extractDir = params.getInstallationDir(version)
-  # Make sure no stale files from previous installation exist.
-  removeDir(extractDir)
-  extract(path, extractDir)
-  # A "special" version is downloaded from GitHub and thus needs a `.git`
-  # directory in order to let `koch` know that it should download a "devel"
-  # Nimble.
-  if version.isSpecial:
-    createDir(extractDir / ".git")
+  let
+    extractDir = params.getInstallationDir(version)
+    updated = gitUpdate(version, extractDir)
+
+  if not updated:
+    # Install the requested version.
+    let path = download(version, params)
+    defer:
+      # Delete downloaded file
+      discard tryRemoveFile(path)
+    # Make sure no stale files from previous installation exist.
+    removeDir(extractDir)
+    # Extract the downloaded file.
+    extract(path, extractDir)
+
+    # A "special" version is downloaded from GitHub and thus needs a `.git`
+    # directory in order to let `koch` know that it should download a "devel"
+    # Nimble.
+    if version.isSpecial:
+      gitInit(version, extractDir)
+
   # Build the compiler
   build(extractDir, version, params)
-  # Delete downloaded file
-  discard tryRemoveFile(path)
 
 proc chooseVersion(version: string, params: CliParams) =
   # Command is a version.

--- a/tests/tester.nim
+++ b/tests/tester.nim
@@ -171,3 +171,24 @@ when defined(linux):
       check hasLine(output.processOutput, "switched to nim 1.0.0")
 
       check not dirExists(choosenimDir / "toolchains" / "nim-1.0.0" / "c_code")
+
+test "can update devel with git":
+  beginTest()
+  block:
+    let (output, exitCode) = exec("devel", liveOutput=true)
+    check exitCode == QuitSuccess
+
+    check inLines(output.processOutput, "extracting")
+    check inLines(output.processOutput, "setting")
+    check inLines(output.processOutput, "latest changes")
+    check inLines(output.processOutput, "building")
+
+  block:
+    let (output, exitCode) = exec(@["update", "devel"], liveOutput=true)
+    check exitCode == QuitSuccess
+
+    check not inLines(output.processOutput, "extracting")
+    check not inLines(output.processOutput, "setting")
+    check inLines(output.processOutput, "updating")
+    check inLines(output.processOutput, "latest changes")
+    check inLines(output.processOutput, "building")


### PR DESCRIPTION
If `devel` or `#head`, and `git` binary is available, fetch updates using `git` and rebuild instead of delete/download/csources/rebuild. Else use legacy method.

Additional [testing](https://travis-ci.org/genotrance/choosenim/builds/648760409) takes much longer, perhaps we don't want it.

cc @Araq