### PR TITLE
Fix #122 - openssl crash on osx

### DIFF
--- a/src/choosenim.nims
+++ b/src/choosenim.nims
@@ -1,4 +1,4 @@
 when defined(macosx):
   --define:curl
-
---define:ssl
+else:
+  --define:ssl


### PR DESCRIPTION
Easy fix for #122, we got lucky.