### PR TITLE
Fallback to --latest

### DIFF
--- a/tests/tester.nim
+++ b/tests/tester.nim
@@ -200,7 +200,7 @@ test "can install and update nightlies":
     let (output, exitCode) = exec("devel", liveOutput=true)
 
     # Travis runs into Github API limit
-    if not inLines(output.processOutput, "403"):
+    if not inLines(output.processOutput, "unavailable"):
       check exitCode == QuitSuccess
 
       check inLines(output.processOutput, "devel from")
@@ -215,7 +215,7 @@ test "can install and update nightlies":
         let (output, exitCode) = exec(@["update", "devel"], liveOutput=true)
 
         # Travis runs into Github API limit
-        if not inLines(output.processOutput, "403"):
+        if not inLines(output.processOutput, "unavailable"):
           check exitCode == QuitSuccess
 
           check inLines(output.processOutput, "updating")


### PR DESCRIPTION
Handle case where github API [returns 403](https://travis-ci.org/nimterop/nimterop/jobs/660460678#L100) for nightlies due to rate limiting and revert to `--latest` instead. This helps avoid failures in CI.

[Normal nightlies test case](https://travis-ci.org/dom96/choosenim/jobs/660655778#L2826)
[Fallback test case](https://travis-ci.org/dom96/choosenim/jobs/660655779#L2778)