### PR TITLE
Support wget

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -39,6 +39,9 @@ prompts and enjoy your new Nim and choosenim installation.
 ```
 curl https://nim-lang.org/choosenim/init.sh -sSf | sh
 ```
+```
+wget -qO - https://nim-lang.org/choosenim/init.sh | sh
+```
 
 **Optional:** You can specify the initial version you would like the `init.sh`
               script to install by specifying the ``CHOOSENIM_CHOOSE_VERSION``
@@ -77,6 +80,7 @@ install them accordingly.
 | C compiler | *Downloaded automatically*    |      gcc/clang     |      gcc/clang        |
 | OpenSSL    |          >= 1.0.2k            |      >= 1.0.2k     |         N/A           |
 | curl       |             N/A               |         N/A        | Any recent version    |
+| wget       |             N/A               |      >= 1.20.1     |      >= 1.20.1        |
 
 \* Many macOS dependencies should already be installed. You may need to install
    a C compiler however. More information on dependencies is available

--- a/scripts/choosenim-unix-init.sh
+++ b/scripts/choosenim-unix-init.sh
@@ -18,10 +18,23 @@ CHOOSE_VERSION="${CHOOSENIM_CHOOSE_VERSION:-stable}"
 need_tty=yes
 debug=""
 
+has_curl() {
+  command -v curl >/dev/null 2>&1
+}
+
+has_wget() {
+  command -v wget >/dev/null 2>&1
+}
+
 install() {
   get_platform || return 1
   local platform=$RET_VAL
-  local stable_version=`curl -sSfL https://nim-lang.org/choosenim/stable`
+  local stable_version=
+  if has_curl; then
+    stable_version=`curl -sSfL https://nim-lang.org/choosenim/stable`
+  elif has_wget; then
+    stable_version=`wget -qO - https://nim-lang.org/choosenim/stable`
+  fi
   local filename="choosenim-$stable_version"_"$platform"
   local url="$url_prefix"v"$stable_version/$filename"
 
@@ -42,7 +55,11 @@ install() {
   esac
 
   say "Downloading $filename"
-  curl -sSfL "$url" -o "$temp_prefix/$filename"
+  if has_curl; then
+    curl -sSfL "$url" -o "$temp_prefix/$filename"
+  elif has_wget; then
+    wget -qO "$temp_prefix/$filename" "$url"
+  fi
   chmod +x "$temp_prefix/$filename"
   if [ "$platform" = "windows_amd64" ]; then
     # Extract ZIP for Windows


### PR DESCRIPTION
Tested successfully on Debian Buster without `curl` installed.

To check whether a command exists, I used the code provided in [this StackOverflow answer](https://stackoverflow.com/a/677212).

For your convenience: the [wget(1) man page](https://linux.die.net/man/1/wget).