### PR TITLE
Use GITHUB_TOKEN env var if present

### DIFF
--- a/src/choosenimpkg/cliparams.nim
+++ b/src/choosenimpkg/cliparams.nim
@@ -61,6 +61,12 @@ Commands:
                                  `--installed` only displays versions that
                                  are installed locally (no network requests).
 
+Environment variables:
+  GITHUB_TOKEN          GitHub API Token. Some actions use the GitHub API.
+                        To avoid anonymous-access rate limits, supply a token
+                        generated at https://github.com/settings/tokens/new
+                        with the `public_repo` scope.
+
 Options:
   -h --help             Show this output.
   -y --yes              Agree to every question.

--- a/src/choosenimpkg/download.nim
+++ b/src/choosenimpkg/download.nim
@@ -60,7 +60,7 @@ proc addGithubAuthentication(url:string):string =
   if ghtoken == "":
     return url
   else:
-    return url.replace("https://api.github.com", &"https://{ghtoken}@api.guthub.com")
+    return url.replace("https://api.github.com", "https://" & ghtoken & "@api.guthub.com")
 
 when defined(curl):
   proc checkCurl(code: Code) =

--- a/src/choosenimpkg/download.nim
+++ b/src/choosenimpkg/download.nim
@@ -55,6 +55,13 @@ proc showBar(fraction: float, speed: BiggestInt) =
                 ])
   stdout.flushFile()
 
+proc addGithubAuthentication(url:string):string =
+  let ghtoken = getEnv("GITHUB_TOKEN")
+  if ghtoken == "":
+    return url
+  else:
+    return url.replace("https://api.github.com", &"https://{ghtoken}@api.guthub.com")
+
 when defined(curl):
   proc checkCurl(code: Code) =
     if code != E_OK:
@@ -215,7 +222,7 @@ proc downloadImpl(version: Version, params: CliParams): string =
     if $version in ["#devel", "#head"] and not params.latest:
       # Install nightlies by default for devel channel
       try:
-        let rawContents = retrieveUrl(githubNightliesReleasesUrl)
+        let rawContents = retrieveUrl(githubNightliesReleasesUrl.addGithubAuthentication())
         let parsedContents = parseJson(rawContents)
         url = getNightliesUrl(parsedContents, arch)
         reference = "devel"
@@ -356,7 +363,7 @@ proc retrieveUrl*(url: string): string =
     return client.getContent(url)
 
 proc getOfficialReleases*(params: CliParams): seq[Version] =
-  let rawContents = retrieveUrl(githubTagReleasesUrl)
+  let rawContents = retrieveUrl(githubTagReleasesUrl.addGithubAuthentication())
   let parsedContents = parseJson(rawContents)
   let cutOffVersion = newVersion("0.16.0")
 

--- a/src/choosenimpkg/download.nim
+++ b/src/choosenimpkg/download.nim
@@ -55,7 +55,7 @@ proc showBar(fraction: float, speed: BiggestInt) =
                 ])
   stdout.flushFile()
 
-proc addGithubAuthentication(url:string):string =
+proc addGithubAuthentication(url: string): string =
   let ghtoken = getEnv("GITHUB_TOKEN")
   if ghtoken == "":
     return url

--- a/src/choosenimpkg/download.nim
+++ b/src/choosenimpkg/download.nim
@@ -60,7 +60,9 @@ proc addGithubAuthentication(url:string):string =
   if ghtoken == "":
     return url
   else:
-    return url.replace("https://api.github.com", "https://" & ghtoken & "@api.guthub.com")
+    display("Info:", "Using the 'GITHUB_TOKEN' environment variable for GitHub API Token.",
+            priority=HighPriority)
+    return url.replace("https://api.github.com", "https://" & ghtoken & "@api.github.com")
 
 when defined(curl):
   proc checkCurl(code: Code) =


### PR DESCRIPTION
This change inserts the value of the env var `GITHUB_TOKEN` into the authentication section of Github API URLs.

This is to fix #208 

- I don't know how to build `choosenim` to test this, so I don't know if it works
- I don't know if curl as used by choosenim will accept a URL of this format
- What documentation changes are needed?  Would you rather it be a command line param?

I'm fine if you want to throw this away and do your own implementation.