### PR TITLE
[FIX(algo)] Generate correct error message

### DIFF
--- a/src/choosenim.nim
+++ b/src/choosenim.nim
@@ -50,9 +50,17 @@ proc chooseVersion(version: string, params: CliParams) =
       let path = downloadMingw(params)
       extract(path, getMingwPath(params))
     else:
-      raise newException(ChooseNimError,
-                         "No C compiler found. Nim compiler requires a C compiler.\n" &
-                         "Install clang or gcc using your favourite package manager.")
+      let binName =
+        when defined(OSX):
+          "clang"
+        else:
+          "gcc"
+
+      raise newException(
+        ChooseNimError,
+        "No C compiler found. Nim compiler requires a C compiler.\n" &
+        "Install " & binName & " using your favourite package manager."
+      )
 
   # Verify that DLLs (openssl primarily) are installed.
   when defined(windows):

--- a/src/choosenim.nim
+++ b/src/choosenim.nim
@@ -51,7 +51,7 @@ proc chooseVersion(version: string, params: CliParams) =
       extract(path, getMingwPath(params))
     else:
       let binName =
-        when defined(OSX):
+        when defined(macosx):
           "clang"
         else:
           "gcc"

--- a/src/choosenimpkg/switcher.nim
+++ b/src/choosenimpkg/switcher.nim
@@ -50,7 +50,7 @@ proc areProxiesInstalled(params: CliParams, proxies: openarray[string]): bool =
 
 proc isDefaultCCInPath*(params: CliParams): bool =
   # Fixes issue #104
-  when defined(OSX):
+  when defined(macosx):
     return findExe("clang") != ""
   else:
     return findExe("gcc") != ""


### PR DESCRIPTION
Generate correct error message on missing C compiler based on target
OS - `clang` for OSX and `gcc` for linux.