### PR TITLE
Static link glibc. Fixes #216.

### DIFF
--- a/src/choosenim.nim.cfg
+++ b/src/choosenim.nim.cfg
@@ -1,0 +1,9 @@
+@if macosx:
+  --define:curl
+@else:
+  --define:ssl
+@end
+
+@if linux:
+  passL = "-static"
+@end

--- a/src/choosenim.nims
+++ b/src/choosenim.nims
@@ -1,4 +1,0 @@
-when defined(macosx):
-  --define:curl
-else:
-  --define:ssl


### PR DESCRIPTION
Before:

```
$ ldd bin/choosenim
        linux-vdso.so.1 (0x00007fffdc079000)
        librt.so.1 => /lib/x86_64-linux-gnu/librt.so.1 (0x00007fb945910000)
        libdl.so.2 => /lib/x86_64-linux-gnu/libdl.so.2 (0x00007fb945700000)
        libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007fb945300000)
        libpthread.so.0 => /lib/x86_64-linux-gnu/libpthread.so.0 (0x00007fb9450e0000)
        /lib64/ld-linux-x86-64.so.2 (0x00007fb946200000)
```

After:
```
$ ldd bin/choosenim
        not a dynamic executable
```