### PR TITLE
Static build with musl

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,12 +6,18 @@ os:
 language: c
 
 env:
-  - BRANCH=1.2.4
+  - BRANCH=1.2.6
 
 cache:
   directories:
     - "$HOME/.choosenim"
     - "$TRAVIS_BUILD_DIR/git"
+
+addons:
+  apt:
+    update: true
+    packages:
+      - musl-tools
 
 install:
   # Use common Travis script maintained as a gist

--- a/choosenim.nimble
+++ b/choosenim.nimble
@@ -13,7 +13,8 @@ skipExt = @["nim"]
 
 # Dependencies
 
-requires "nim >= 1.2.4", "nimble#14a6946", "nimarchive >= 0.5.2"
+requires "nim >= 1.2.6", "nimble#26167cd"
+requires "nimterop >= 0.6.12", "nimarchive >= 0.5.3"
 requires "libcurl >= 1.0.0"
 requires "analytics >= 0.2.0"
 requires "osinfo >= 0.3.0"

--- a/src/choosenim.nim
+++ b/src/choosenim.nim
@@ -7,7 +7,7 @@ import nimblepkg/common as nimbleCommon
 from nimblepkg/packageinfo import getNameVersion
 
 import choosenimpkg/[download, builder, switcher, common, cliparams, versions]
-import choosenimpkg/[utils, channel, telemetry]
+import choosenimpkg/[utils, channel, ssl, telemetry]
 
 when defined(windows):
   import choosenimpkg/env

--- a/src/choosenim.nims
+++ b/src/choosenim.nims
@@ -1,4 +1,12 @@
-when defined(macosx):
-  --define:curl
-else:
-  --define:ssl
+when findExe("musl-gcc").len != 0:
+  # Use musl-gcc when available
+  putEnv("CC", "musl-gcc")
+  switch("gcc.exe", "musl-gcc")
+  switch("gcc.linkerexe", "musl-gcc")
+
+# Statically linking everything
+when not defined(OSX):
+  switch("passL", "-static")
+switch("define", "ssl")
+switch("dynlibOverride", "ssl")
+switch("dynlibOverride", "crypto")

--- a/src/choosenimpkg/ssl.nim
+++ b/src/choosenimpkg/ssl.nim
@@ -1,0 +1,20 @@
+import strutils
+
+import nimterop/[build, cimport]
+
+# Download openssl from JuliaBinaryWrappers
+setDefines(@[
+  "cryptoJBB", "cryptoStatic"
+])
+
+getHeader(
+  "crypto.h",
+  jbburi = "openssl",
+  outdir = getProjectCacheDir("nimopenssl")
+)
+
+const
+  sslLPath = cryptoLPath.replace("crypto", "ssl")
+
+# Link static binaries
+{.passL: sslLPath & " " & cryptoLPath.}


### PR DESCRIPTION
Fixes #216 - Linux version is built with musl

All builds include openssl statically linked so don't need to bundle DLLs for Windows or use curl on OSX.