### PR TITLE
Nightly update improvements

### DIFF
--- a/changelog.markdown
+++ b/changelog.markdown
@@ -1,12 +1,21 @@
 # Choosenim changelog
 
-## 0.6.2 - xx/xx/2020
+## 0.7.0 - 16/10/2020
+
+The major new feature is that all builds are now static. There should be no
+runtime dependencies for choosenim anymore.
 
 Changes:
 
+* A critical bug was fixed where choosenim would fail if existng DLLs were present.
 * The `update` command will now always change to the newly installed version.
   In previous versions this would only happen when the currently selected
   channel is updated.
+* A new `remove` command is now available.
+* The `nim-gdb` utility is now shimmed.
+* Various small bug fixes, #203 and #195.
+* The `GITHUB_TOKEN` env var will now be used if present for certain actions.
+* Better messages when downloading nightlies.
 
 ## 0.6.0 - 06/03/2020
 

--- a/changelog.markdown
+++ b/changelog.markdown
@@ -1,5 +1,13 @@
 # Choosenim changelog
 
+## 0.6.2 - xx/xx/2020
+
+Changes:
+
+* The `update` command will now always change to the newly installed version.
+  In previous versions this would only happen when the currently selected
+  channel is updated.
+
 ## 0.6.0 - 06/03/2020
 
 The major new feature is default installation of 64-bit Nim

--- a/choosenim.nimble
+++ b/choosenim.nimble
@@ -1,6 +1,6 @@
 # Package
 
-version       = "0.6.1"
+version       = "0.7.0"
 author        = "Dominik Picheta"
 description   = "The Nim toolchain installer."
 license       = "MIT"

--- a/src/choosenim.nim
+++ b/src/choosenim.nim
@@ -177,10 +177,8 @@ proc update(params: CliParams) =
 
   display("Updated", "to " & $version, Success, HighPriority)
 
-  # If the currently selected channel is the one that was updated, switch to
-  # the new version.
-  if getCurrentChannel(params) == channel:
-    switchTo(version, params)
+  # Always switch to the updated version.
+  switchTo(version, params)
 
 proc show(params: CliParams) =
   let channel = getCurrentChannel(params)

--- a/src/choosenimpkg/common.nim
+++ b/src/choosenimpkg/common.nim
@@ -4,7 +4,7 @@ type
   ChooseNimError* = object of NimbleError
 
 const
-  chooseNimVersion* = "0.6.1"
+  chooseNimVersion* = "0.7.0"
 
   proxies* = [
       "nim",

--- a/src/choosenimpkg/utils.nim
+++ b/src/choosenimpkg/utils.nim
@@ -117,25 +117,24 @@ proc getLatestCommit*(repo, branch: string): string =
     else:
       display("Warning", outp & "\ngit ls-remote failed", Warning, HighPriority)
 
-proc getNightliesUrl*(parsedContents: JsonNode, arch: int): string =
+proc getNightliesUrl*(parsedContents: JsonNode, arch: int): (string, string) =
   let os =
     when defined(windows): "windows"
     elif defined(linux): "linux"
     elif defined(macosx): "osx"
   for jn in parsedContents.getElems():
     if jn["name"].getStr().contains("devel"):
+      let tagName = jn{"tag_name"}.getStr("")
       for asset in jn["assets"].getElems():
         let aname = asset["name"].getStr()
+        let url = asset{"browser_download_url"}.getStr("")
         if os in aname:
           when not defined(macosx):
             if "x" & $arch in aname:
-              result = asset["browser_download_url"].getStr()
+              result = (url, tagName)
           else:
-            result = asset["browser_download_url"].getStr()
-        if result.len != 0:
+            result = (url, tagName)
+        if result[0].len != 0:
           break
-    if result.len != 0:
+    if result[0].len != 0:
       break
-  if result.len == 0:
-    display("Warning", "Recent nightly release not found, installing latest devel commit.",
-            Warning, priority = HighPriority)


### PR DESCRIPTION
We now get the tag name in the "Downloading" message:

![image](https://user-images.githubusercontent.com/246651/95396788-997e4400-08f9-11eb-99c6-5ee22a2d821c.png)

Plus the behaviour of `update` changed (see changelog).

**Future improvements:** we should have ``download.downloadImpl`` return ``(string, Version)``, the latter being the version that has been downloaded. Sadly it looks like we'll have to parse out the commit from the tag name to get this for the nightlies. This is a minor thing, but it will allow us to display "Updated to \<commit hash\>" rather than "Updated to #devel".