### PR TITLE
Linux build, windows init.sh fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,11 @@ addons:
     packages:
       - musl-tools
 
+# Don't rebuild autotagged
+branches:
+  except:
+  - /^v[0-9.]+-[0-9]+-[0-9a-f]+$/
+
 script:
   - source ./scripts/build.sh
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ os:
 language: c
 
 env:
-  - BRANCH=1.2.6
+  - BRANCH=1.2.8
 
 cache:
   directories:

--- a/choosenim.nimble
+++ b/choosenim.nimble
@@ -1,6 +1,6 @@
 # Package
 
-version       = "0.7.4"
+version       = "0.7.5"
 author        = "Dominik Picheta"
 description   = "The Nim toolchain installer."
 license       = "MIT"

--- a/choosenim.nimble
+++ b/choosenim.nimble
@@ -18,7 +18,3 @@ requires "nimterop >= 0.6.12", "nimarchive >= 0.5.3"
 #requires "libcurl >= 1.0.0" - OSX now uses httpclient
 requires "analytics >= 0.2.0"
 requires "osinfo >= 0.3.0"
-
-task test, "Run the choosenim tester!":
-  withDir "tests":
-    exec "nim c -r tester"

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -36,7 +36,8 @@ else
 
   # Build release version
   nimble install -y -d
-  nim c -d:release --outdir:bin ${FLAGS} src/choosenim
+  nim c -d:release ${FLAGS} src/choosenimpkg/proxyexe
+  nim c -d:release --outdir:bin -d:skipBuild ${FLAGS} src/choosenim
   strip "bin/choosenim${EXT}"
 
   # Set version and tag info
@@ -72,7 +73,8 @@ else
   mv "bin/choosenim${EXT}" "${FILENAME}_debug${EXT}"
 
   # Build debug version
-  nim c -g --outdir:bin ${FLAGS} src/choosenim
+  nim c -g ${FLAGS} src/choosenimpkg/proxyexe
+  nim c -g --outdir:bin -d:skipBuild ${FLAGS} src/choosenim
   ./bin/choosenim${EXT} -v
   mv "bin/choosenim${EXT}" "${FILENAME}${EXT}"
 fi

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -6,62 +6,60 @@ source travis.sh
 
 # Skip building autotagged version
 export COMMIT_TAG=`git tag --points-at HEAD | head -n 1`
+export COMMIT_HASH=`git rev-parse --short HEAD`
 export CURRENT_BRANCH="${TRAVIS_BRANCH}"
 echo "Commit tag: ${COMMIT_TAG}"
+echo "Commit hash: ${COMMIT_HASH}"
 echo "Current branch: ${CURRENT_BRANCH}"
-if [[ "${COMMIT_TAG}" =~ ^v[0-9.]+-[0-9]+$ ]]; then
-  echo "Skipping build since autotagged version"
+
+# Environment vars
+if [[ "$TRAVIS_OS_NAME" == "windows" ]]; then
+  export EXT=".exe"
 else
-  # Environment vars
-  if [[ "$TRAVIS_OS_NAME" == "windows" ]]; then
-    export EXT=".exe"
-  else
-    export EXT=""
-  fi
-
-  if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
-    export OSNAME="macosx"
-  else
-    export OSNAME="$TRAVIS_OS_NAME"
-  fi
-
-  # Build release version
-  nimble build -y -d:release -d:staticBuild
-
-  # Set version and tag info
-  export CHOOSENIM_VERSION="$(./bin/choosenim --version | cut -f2,2 -d' ' | sed 's/v//')"
-  echo "Version: v${CHOOSENIM_VERSION}"
-  if [[ -z "${COMMIT_TAG}" ]]; then
-    # Create tag with date, not an official tagged release
-    export VERSION_TAG="${CHOOSENIM_VERSION}-$(date +'%Y%m%d')"
-    if [[ "${CURRENT_BRANCH}" == "master" ]]; then
-      # Deploy only on main branch
-      export TRAVIS_TAG="v${VERSION_TAG}"
-      export PRERELEASE=true
-    fi
-  elif [[ "${COMMIT_TAG}" == "v${CHOOSENIM_VERSION}" ]]; then
-    # Official tagged release
-    export VERSION_TAG="${CHOOSENIM_VERSION}"
-    export TRAVIS_TAG="${COMMIT_TAG}"
-  else
-    echo "Tag does not match choosenim version"
-    echo "  Commit tag: ${COMMIT_TAG}"
-    echo "  Version: v${CHOOSENIM_VERSION}"
-    echo "  Current branch: ${CURRENT_BRANCH}"
-    travis_terminate 1
-  fi
-  echo "Travis tag: ${TRAVIS_TAG}"
-  echo "Prerelease: ${PRERELEASE}"
-  export FILENAME="bin/choosenim-${VERSION_TAG}_${OSNAME}_${TRAVIS_CPU_ARCH}"
-  echo "Filename: ${FILENAME}"
-
-  # Run tests
-  nimble test -d:release -d:staticBuild
-  strip "bin/choosenim${EXT}"
-  mv "bin/choosenim${EXT}" "${FILENAME}${EXT}"
-
-  # Build debug version
-  nimble build -g -d:staticBuild
-  ./bin/choosenim${EXT} -v
-  mv "bin/choosenim${EXT}" "${FILENAME}_debug${EXT}"
+  export EXT=""
 fi
+
+if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
+  export OSNAME="macosx"
+else
+  export OSNAME="$TRAVIS_OS_NAME"
+fi
+
+# Build release version
+nimble build -y -d:release -d:staticBuild
+
+# Set version and tag info
+export CHOOSENIM_VERSION="$(./bin/choosenim --version | cut -f2,2 -d' ' | sed 's/v//')"
+echo "Version: v${CHOOSENIM_VERSION}"
+if [[ -z "${COMMIT_TAG}" ]]; then
+  # Create tag with date and hash, not an official tagged release
+  export VERSION_TAG="${CHOOSENIM_VERSION}-$(date +'%Y%m%d')-${COMMIT_HASH}"
+  if [[ "${CURRENT_BRANCH}" == "master" ]]; then
+    # Deploy only on main branch
+    export TRAVIS_TAG="v${VERSION_TAG}"
+    export PRERELEASE=true
+  fi
+elif [[ "${COMMIT_TAG}" == "v${CHOOSENIM_VERSION}" ]]; then
+  # Official tagged release
+  export VERSION_TAG="${CHOOSENIM_VERSION}"
+  export TRAVIS_TAG="${COMMIT_TAG}"
+else
+  # Other tag, mostly autotagged rebuild
+  export VERSION_TAG="${COMMIT_TAG:1}"
+  export TRAVIS_TAG="${COMMIT_TAG}"
+  export PRERELEASE=true
+fi
+echo "Travis tag: ${TRAVIS_TAG}"
+echo "Prerelease: ${PRERELEASE}"
+export FILENAME="bin/choosenim-${VERSION_TAG}_${OSNAME}_${TRAVIS_CPU_ARCH}"
+echo "Filename: ${FILENAME}"
+
+# Run tests
+nimble test -d:release -d:staticBuild
+strip "bin/choosenim${EXT}"
+mv "bin/choosenim${EXT}" "${FILENAME}${EXT}"
+
+# Build debug version
+nimble build -g -d:staticBuild
+./bin/choosenim${EXT} -v
+mv "bin/choosenim${EXT}" "${FILENAME}_debug${EXT}"

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -25,20 +25,8 @@ else
     export OSNAME="$TRAVIS_OS_NAME"
   fi
 
-  if [[ "$OSNAME" == "linux" ]]; then
-    # musl-gcc static build for Linux
-    export CC=musl-gcc # for nimterop
-    export FLAGS="--gcc.exe:musl-gcc --gcc.linkerexe:musl-gcc --passL:-static"
-  elif [[ "$OSNAME" == "windows" ]]; then
-    # Static build on Windows
-    export FLAGS="--passL:-static"
-  fi
-
   # Build release version
-  nimble install -y -d
-  nim c -d:release ${FLAGS} src/choosenimpkg/proxyexe
-  nim c -d:release --outdir:bin -d:skipBuild ${FLAGS} src/choosenim
-  strip "bin/choosenim${EXT}"
+  nimble build -y -d:release -d:staticBuild
 
   # Set version and tag info
   export CHOOSENIM_VERSION="$(./bin/choosenim --version | cut -f2,2 -d' ' | sed 's/v//')"
@@ -64,17 +52,16 @@ else
   fi
   echo "Travis tag: ${TRAVIS_TAG}"
   echo "Prerelease: ${PRERELEASE}"
-  echo "Flags: ${FLAGS}"
   export FILENAME="bin/choosenim-${VERSION_TAG}_${OSNAME}_${TRAVIS_CPU_ARCH}"
   echo "Filename: ${FILENAME}"
 
   # Run tests
-  nimble test -d:skipBuild
-  mv "bin/choosenim${EXT}" "${FILENAME}_debug${EXT}"
+  nimble test -d:release -d:staticBuild
+  strip "bin/choosenim${EXT}"
+  mv "bin/choosenim${EXT}" "${FILENAME}${EXT}"
 
   # Build debug version
-  nim c -g ${FLAGS} src/choosenimpkg/proxyexe
-  nim c -g --outdir:bin -d:skipBuild ${FLAGS} src/choosenim
+  nimble build -g -d:staticBuild
   ./bin/choosenim${EXT} -v
-  mv "bin/choosenim${EXT}" "${FILENAME}${EXT}"
+  mv "bin/choosenim${EXT}" "${FILENAME}_debug${EXT}"
 fi

--- a/scripts/choosenim-unix-init.sh
+++ b/scripts/choosenim-unix-init.sh
@@ -82,7 +82,6 @@ install() {
   # Copy choosenim binary to Nimble bin.
   local nimbleBinDir=`"$temp_prefix/$filename" --getNimbleBin`
   cp "$temp_prefix/$filename" "$nimbleBinDir/choosenim$ext"
-  fi
   say "ChooseNim installed in $nimbleBinDir"
   say "You must now ensure that the Nimble bin dir is in your PATH."
   if [ "$platform" != "windows_amd64" ]; then

--- a/scripts/choosenim-unix-init.sh
+++ b/scripts/choosenim-unix-init.sh
@@ -37,14 +37,16 @@ install() {
   fi
   local filename="choosenim-$stable_version"_"$platform"
   local url="$url_prefix"v"$stable_version/$filename"
+  local ext=""
 
   case $platform in
     *macosx_amd64* | *linux_amd64* )
       ;;
     *windows_amd64* )
       # Download ZIP for Windows
-      local filename="$filename.zip"
-      local url="$url.zip"
+      local ext=".exe"
+      local filename="$filename$ext"
+      local url="$url$ext"
       ;;
     * )
       say_err "Sorry, your platform ($platform) is not supported by choosenim."
@@ -61,11 +63,6 @@ install() {
     wget -qO "$temp_prefix/$filename" "$url"
   fi
   chmod +x "$temp_prefix/$filename"
-  if [ "$platform" = "windows_amd64" ]; then
-    # Extract ZIP for Windows
-    unzip -j -o -d $temp_prefix/choosenim $temp_prefix/$filename
-    local filename="choosenim/choosenim.exe"
-  fi
 
   if [ "$need_tty" = "yes" ]; then
     # The installer is going to want to ask for confirmation by
@@ -84,10 +81,7 @@ install() {
 
   # Copy choosenim binary to Nimble bin.
   local nimbleBinDir=`"$temp_prefix/$filename" --getNimbleBin`
-  if [ "$platform" = "windows_amd64" ]; then
-    cp "$temp_prefix/$filename" "$nimbleBinDir/."
-  else
-    cp "$temp_prefix/$filename" "$nimbleBinDir/choosenim"
+  cp "$temp_prefix/$filename" "$nimbleBinDir/choosenim$ext"
   fi
   say "ChooseNim installed in $nimbleBinDir"
   say "You must now ensure that the Nimble bin dir is in your PATH."

--- a/src/choosenim.nims
+++ b/src/choosenim.nims
@@ -1,8 +1,3 @@
-when defined(linux):
-  switch("passL", "-lpthread")
-elif defined(windows):
-  switch("passL", "-lws2_32")
-
 switch("define", "ssl")
 
 when defined(windows):
@@ -11,7 +6,11 @@ when defined(windows):
   switch("dynlibOverride", "ssl-")
   switch("dynlibOverride", "crypto-")
   switch("define", "sslVersion:(")
-
 else:
   switch("dynlibOverride", "ssl")
   switch("dynlibOverride", "crypto")
+
+when defined(linux):
+  switch("passL", "-lpthread")
+elif defined(windows):
+  switch("passL", "-lws2_32")

--- a/src/choosenim.nims
+++ b/src/choosenim.nims
@@ -10,7 +10,5 @@ else:
   switch("dynlibOverride", "ssl")
   switch("dynlibOverride", "crypto")
 
-when defined(linux):
-  switch("passL", "-lpthread")
-elif defined(windows):
-  switch("passL", "-lws2_32")
+when defined(staticBuild):
+  import "choosenimpkg/proxyexe.nims"

--- a/src/choosenim.nims
+++ b/src/choosenim.nims
@@ -1,17 +1,20 @@
-when findExe("musl-gcc").len != 0:
+const musl = findExe("musl-gcc").len != 0
+
+when musl:
   # Use musl-gcc when available
   putEnv("CC", "musl-gcc")
   switch("gcc.exe", "musl-gcc")
   switch("gcc.linkerexe", "musl-gcc")
+elif defined(linux):
+  switch("passL", "-lpthread")
 
-# Statically linking everything
-when not defined(OSX):
+when musl or defined(windows):
   switch("passL", "-static")
 
 switch("define", "ssl")
 
 when defined(windows):
-  # TODO: change once issue nim#15520 is resolved
+  # TODO: change once issue nim#15220 is resolved
   switch("define", "noOpenSSLHacks")
   switch("dynlibOverride", "ssl-")
   switch("dynlibOverride", "crypto-")

--- a/src/choosenim.nims
+++ b/src/choosenim.nims
@@ -1,15 +1,7 @@
-const musl = findExe("musl-gcc").len != 0
-
-when musl:
-  # Use musl-gcc when available
-  putEnv("CC", "musl-gcc")
-  switch("gcc.exe", "musl-gcc")
-  switch("gcc.linkerexe", "musl-gcc")
-elif defined(linux):
+when defined(linux):
   switch("passL", "-lpthread")
-
-when musl or defined(windows):
-  switch("passL", "-static")
+elif defined(windows):
+  switch("passL", "-lws2_32")
 
 switch("define", "ssl")
 
@@ -20,7 +12,6 @@ when defined(windows):
   switch("dynlibOverride", "crypto-")
   switch("define", "sslVersion:(")
 
-  switch("passL", "-lws2_32")
 else:
   switch("dynlibOverride", "ssl")
   switch("dynlibOverride", "crypto")

--- a/src/choosenimpkg/common.nim
+++ b/src/choosenimpkg/common.nim
@@ -4,7 +4,7 @@ type
   ChooseNimError* = object of NimbleError
 
 const
-  chooseNimVersion* = "0.7.4"
+  chooseNimVersion* = "0.7.5"
 
   proxies* = [
       "nim",

--- a/src/choosenimpkg/proxyexe.nims
+++ b/src/choosenimpkg/proxyexe.nims
@@ -1,0 +1,7 @@
+when defined(staticBuild):
+  when defined(linux):
+    putEnv("CC", "musl-gcc")
+    switch("gcc.exe", "musl-gcc")
+    switch("gcc.linkerexe", "musl-gcc")
+  when not defined(OSX):
+    switch("passL", "-static")

--- a/src/choosenimpkg/ssl.nim
+++ b/src/choosenimpkg/ssl.nim
@@ -1,6 +1,6 @@
 import strutils
 
-import nimterop/[build, cimport]
+import nimterop/build
 
 # Download openssl from JuliaBinaryWrappers
 setDefines(@[

--- a/src/choosenimpkg/ssl.nim
+++ b/src/choosenimpkg/ssl.nim
@@ -1,3 +1,5 @@
+{.used}
+
 import strutils
 
 import nimterop/build
@@ -18,3 +20,9 @@ const
 
 # Link static binaries
 {.passL: sslLPath & " " & cryptoLPath.}
+
+# Deps for openssl
+when defined(linux):
+  {.passL: "-lpthread".}
+elif defined(windows):
+  {.passL: "-lws2_32".}

--- a/src/choosenimpkg/switcher.nim
+++ b/src/choosenimpkg/switcher.nim
@@ -11,7 +11,7 @@ when defined(windows):
 proc compileProxyexe() =
   var cmd = "nim c"
   when defined(release):
-    cmd.add " -d:danger"
+    cmd.add " -d:release"
   when defined(staticBuild):
     cmd.add " -d:staticBuild"
   cmd.add " proxyexe"

--- a/src/choosenimpkg/switcher.nim
+++ b/src/choosenimpkg/switcher.nim
@@ -8,16 +8,17 @@ import cliparams, common
 when defined(windows):
   import env
 
-when not defined(skipBuild):
-  proc compileProxyexe() =
-    var cmd = "nim c"
-    when defined(release):
-      cmd.add " -d:release"
-    cmd.add " proxyexe"
-    let (output, exitCode) = gorgeEx(cmd)
-    doAssert exitCode == 0, $(output, cmd)
+proc compileProxyexe() =
+  var cmd = "nim c"
+  when defined(release):
+    cmd.add " -d:danger"
+  when defined(staticBuild):
+    cmd.add " -d:staticBuild"
+  cmd.add " proxyexe"
+  let (output, exitCode) = gorgeEx(cmd)
+  doAssert exitCode == 0, $(output, cmd)
 
-  static: compileProxyexe()
+static: compileProxyexe()
 
 const
   proxyExe = staticRead("proxyexe".addFileExt(ExeExt))

--- a/src/choosenimpkg/switcher.nim
+++ b/src/choosenimpkg/switcher.nim
@@ -8,15 +8,16 @@ import cliparams, common
 when defined(windows):
   import env
 
-proc compileProxyexe() =
-  var cmd = "nim c"
-  when defined(release):
-    cmd.add " -d:release"
-  cmd.add " proxyexe"
-  let (output, exitCode) = gorgeEx(cmd)
-  doAssert exitCode == 0, $(output, cmd)
+when not defined(skipBuild):
+  proc compileProxyexe() =
+    var cmd = "nim c"
+    when defined(release):
+      cmd.add " -d:release"
+    cmd.add " proxyexe"
+    let (output, exitCode) = gorgeEx(cmd)
+    doAssert exitCode == 0, $(output, cmd)
 
-static: compileProxyexe()
+  static: compileProxyexe()
 
 const
   proxyExe = staticRead("proxyexe".addFileExt(ExeExt))

--- a/tests/tester.nim
+++ b/tests/tester.nim
@@ -1,8 +1,8 @@
 # Copyright (C) Dominik Picheta. All rights reserved.
 # BSD-3-Clause License. Look at license.txt for more info.
-import osproc, streams, unittest, strutils, os, sequtils, future
+import osproc, streams, unittest, strutils, os, sequtils, sugar
 
-var rootDir = getCurrentDir().parentDir()
+var rootDir = getCurrentDir()
 var exePath = rootDir / "bin" / addFileExt("choosenim", ExeExt)
 var nimbleDir = rootDir / "tests" / "nimbleDir"
 var choosenimDir = rootDir / "tests" / "choosenimDir"
@@ -106,8 +106,8 @@ proc hasLine(lines: seq[string], line: string): bool =
   for i in lines:
     if i.normalize.strip() == line.normalize(): return true
 
-test "can compile choosenim":
-  cd "..":
+when not defined(skipBuild):
+  test "can compile choosenim":
     let (_, exitCode) = exec("build", exe="nimble", global=true, liveOutput=true)
     check exitCode == QuitSuccess
 

--- a/tests/tester.nim
+++ b/tests/tester.nim
@@ -106,10 +106,14 @@ proc hasLine(lines: seq[string], line: string): bool =
   for i in lines:
     if i.normalize.strip() == line.normalize(): return true
 
-when not defined(skipBuild):
-  test "can compile choosenim":
-    let (_, exitCode) = exec("build", exe="nimble", global=true, liveOutput=true)
-    check exitCode == QuitSuccess
+test "can compile choosenim":
+  var args = @["build"]
+  when defined(release):
+    args.add "-d:release"
+  when defined(staticBuild):
+    args.add "-d:staticBuild"
+  let (_, exitCode) = exec(args, exe="nimble", global=true, liveOutput=true)
+  check exitCode == QuitSuccess
 
 test "refuses invalid path":
   beginTest()


### PR DESCRIPTION
- Switch init.sh to download standalone binary on windows
- musl static building only in CI
- Fixes #239 - not building on Linux w/o musl
- Fixes #216 - musl support for proxyexe