### PR TITLE
fix: run choosenim update stable before downloading nim

### DIFF
--- a/scripts/choosenim-unix-init.sh
+++ b/scripts/choosenim-unix-init.sh
@@ -78,6 +78,7 @@ install() {
     # Install Nim from desired channel.
     "$temp_prefix/$filename" $CHOOSE_VERSION --firstInstall ${debug} < /dev/tty
   else
+    "$temp_prefix/$filename" update $CHOOSE_VERSION -y
     "$temp_prefix/$filename" $CHOOSE_VERSION --firstInstall -y ${debug}
   fi
 

--- a/scripts/choosenim-unix-init.sh
+++ b/scripts/choosenim-unix-init.sh
@@ -30,6 +30,7 @@ install() {
   get_platform || return 1
   local platform=$RET_VAL
   local stable_version=
+
   if has_curl; then
     stable_version=`curl -sSfL https://nim-lang.org/choosenim/stable`
   elif has_wget; then
@@ -63,6 +64,9 @@ install() {
     wget -qO "$temp_prefix/$filename" "$url"
   fi
   chmod +x "$temp_prefix/$filename"
+
+  # Update any existing local stable version to the latest nim stable version.
+  "$temp_prefix/$filename" update stable
 
   if [ "$need_tty" = "yes" ]; then
     # The installer is going to want to ask for confirmation by

--- a/scripts/choosenim-unix-init.sh
+++ b/scripts/choosenim-unix-init.sh
@@ -64,9 +64,6 @@ install() {
   fi
   chmod +x "$temp_prefix/$filename"
 
-  # Update any existing local stable version to the latest nim stable version.
-  "$temp_prefix/$filename" update stable
-
   if [ "$need_tty" = "yes" ]; then
     # The installer is going to want to ask for confirmation by
     # reading stdin.  This script was piped into `sh` though and
@@ -76,6 +73,8 @@ install() {
       err "Unable to run interactively. Run with -y to accept defaults."
     fi
 
+    # Update any existing local version.
+    "$temp_prefix/$filename" update $CHOOSE_VERSION < /dev/tty
     # Install Nim from desired channel.
     "$temp_prefix/$filename" $CHOOSE_VERSION --firstInstall ${debug} < /dev/tty
   else

--- a/scripts/choosenim-unix-init.sh
+++ b/scripts/choosenim-unix-init.sh
@@ -30,7 +30,6 @@ install() {
   get_platform || return 1
   local platform=$RET_VAL
   local stable_version=
-
   if has_curl; then
     stable_version=`curl -sSfL https://nim-lang.org/choosenim/stable`
   elif has_wget; then


### PR DESCRIPTION
Resolves  #264 

Run `choosenim update stable` before downloading and installing nim.
This prevents a local `stable` pointing to an old version of nim.`