### PR TITLE
Add FreeBSD support

### DIFF
--- a/src/choosenimpkg/utils.nim
+++ b/src/choosenimpkg/utils.nim
@@ -167,6 +167,7 @@ proc getNightliesUrl*(parsedContents: JsonNode, arch: int): (string, string) =
     when defined(windows): "windows"
     elif defined(linux): "linux"
     elif defined(macosx): "osx"
+    elif defined(freebsd): "freebsd"
   for jn in parsedContents.getElems():
     if jn["name"].getStr().contains("devel"):
       let tagName = jn{"tag_name"}.getStr("")


### PR DESCRIPTION
This line allows us to build and use choosenim on FreeBSD.

Previously this error was raised:

`/tmp/nimble_50804/githubcom_dom96choosenim/src/choosenimpkg/utils.nim(167, 5) Error: expression '' has no type (or is ambiguous)
`