### PR TITLE
build arm64 even on rosetta ... improve #149

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,13 @@ os:
   - osx
   - windows
 
+dist: bionic
+osx_image: xcode12.3
+
 language: c
 
 env:
-  - BRANCH=1.2.8
+  - BRANCH=1.4.4
 
 cache:
   directories:

--- a/src/choosenimpkg/utils.nim
+++ b/src/choosenimpkg/utils.nim
@@ -30,25 +30,14 @@ proc parseVersion*(versionStr: string): Version =
 
   result = newVersion(versionStr)
 
-proc isRosetta(): bool =
-  let res = execCmdEx("sysctl -in sysctl.proc_translated")
-  if res.exitCode == 0:
-    return res.output.strip() == "1"
-  return false
-
 proc doCmdRaw*(cmd: string) =
-  var command = cmd
   # To keep output in sequence
   stdout.flushFile()
   stderr.flushFile()
 
-  if defined(macosx) and isRosetta():
-    command = "arch -arm64 " & cmd
-
-  displayDebug("Executing", command)
+  displayDebug("Executing", cmd)
   displayDebug("Work Dir", getCurrentDir())
-
-  let (output, exitCode) = execCmdEx(command)
+  let (output, exitCode) = execCmdEx(cmd)
   displayDebug("Finished", "with exit code " & $exitCode)
   displayDebug("Output", output)
 


### PR DESCRIPTION
On M1 macs, since we don't have arm binaries for choosenim, we can use x86 choosenim to download and invoke compiler. By default choosenim under rosetta build x86 nim. But passing arch -arm64 will build arm64 nim binary. This add improvement to #149.