### PR TITLE
Update Puppy dep version

### DIFF
--- a/choosenim.nimble
+++ b/choosenim.nimble
@@ -21,7 +21,7 @@ requires "analytics >= 0.3.0"
 requires "osinfo >= 0.3.0"
 requires "zippy >= 0.7.2"
 when defined(windows):
-  requires "puppy 1.2.1"
+  requires "puppy 1.5.3"
 
 task release, "Build a release binary":
   exec "nimble build -d:release"


### PR DESCRIPTION
Related issue: https://github.com/dom96/choosenim/issues/287

This PR updates Puppy's dep version. This does a few things:
1) Lowers Puppy's minimum required Nim version to below that of choosenim, addressing issue #287 
2) I redid Puppy's internals for Windows a while back. It is better and I know choosenim uses Puppy on Windows so this is relevant.

There no changes to Puppy that necessitate any changes in choosenim.