### PR TITLE
build fat binaries on macosx

### DIFF
--- a/src/choosenim.nims
+++ b/src/choosenim.nims
@@ -1,5 +1,7 @@
 when defined(macosx):
   switch("define", "curl")
+  switch("passC","-arch arm64 -arch x86_64")
+  switch("passL","-arch arm64 -arch x86_64")
 elif not defined(windows):
   switch("define", "ssl")
 


### PR DESCRIPTION
It looks like choosenim is still using rosetta x86 builds for M1 based Macs. This change _should_ get the macosx build to generate "fat binaries" that support both x86_64 and arm64 variants. 

I'm testing it on my M1, but don't have access to an x86 Mac to verify the binaries work there as well. 