### PR TITLE
Adding workflow to automatically build and upload binaries

### DIFF
--- a/.github/workflows/release_build.yml
+++ b/.github/workflows/release_build.yml
@@ -26,9 +26,6 @@ jobs:
       - uses: actions/checkout@v2
       - name: Build binary
         run: |
-          echo `pwd`
-          echo ${{ runner.workspace }}
-          exit -1
           CHOOSENIM_DIR=`pwd`
           # checking out and compiling nim version-1-6 from git
           mkdir -p nimDir
@@ -44,6 +41,8 @@ jobs:
           cd $CHOOSENIM_DIR
           nimble install -y
           nimble build
+          ls bin/*
+          
       - name: Upload binaries to release
         uses: svenstaro/upload-release-action@v2
         with:
@@ -51,7 +50,7 @@ jobs:
           overwrite: true    
           tag: ${{ github.ref }}
           asset_name: choosenim-manylinux2014
-          file: bin/choosenim*   
+          file: ${{ runner.workspace }}/choosenim/bin/choosenim*   
 
   # ----------------------------------------------------------------------------
   build-win32:
@@ -63,8 +62,7 @@ jobs:
         run: |
           nimble install -y
           nimble build
-          dir
-          dir bin/choosenim.exe
+          dir bin/*
           
       - name: Upload binaries to release
         uses: svenstaro/upload-release-action@v2
@@ -73,7 +71,7 @@ jobs:
           overwrite: true    
           tag: ${{ github.ref }}
           asset_name: choosenim-windows
-          file: ${{ runner.workspace }}/bin/choosenim.exe     
+          file: ${{ runner.workspace }}/choosenim/bin/choosenim.exe     
 
   # ----------------------------------------------------------------------------
   build-macos:
@@ -85,8 +83,7 @@ jobs:
         run: |
           nimble install -y
           nimble build
-          ls
-          ls bin
+          ls bin/*
           
       - name: Upload binaries to release
         uses: svenstaro/upload-release-action@v2
@@ -95,4 +92,4 @@ jobs:
           overwrite: true    
           tag: ${{ github.ref }}
           asset_name: choosenim-macos
-          file: ${{ runner.workspace }}/bin/choosenim      
+          file: ${{ runner.workspace }}/choosenim/bin/choosenim      

--- a/.github/workflows/release_build.yml
+++ b/.github/workflows/release_build.yml
@@ -1,0 +1,53 @@
+# This workflow will upload a Python Package using Twine when a release is created
+# For more information see: https://help.github.com/en/actions/language-and-framework-guides/using-python-with-github-actions#publishing-to-package-registries
+
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+name: Build and upload binary
+
+on:  
+  workflow_dispatch:
+  push:
+    paths:
+      - 'choosenim.nimble'
+    branches:
+      - main
+
+jobs:
+ # ----------------------------------------------------------------------------
+  build-linux:
+    runs-on: ubuntu-latest
+    container:
+      image: quay.io/pypa/manylinux2014_x86_64
+    steps:
+      - uses: actions/checkout@v2
+      - uses: iffy/install-nim@v4.0.1
+      - name: Build binary
+        run: |
+          nimble install -y
+          nimble build
+
+  # ----------------------------------------------------------------------------
+  build-win32:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: iffy/install-nim@v4.0.1
+      - name: Build binary
+        run: |
+          nimble install -y
+          nimble build
+
+  # ----------------------------------------------------------------------------
+  build-macos:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: iffy/install-nim@v4.0.1
+      - name: Build binary
+        run: |
+          nimble install -y
+          nimble build

--- a/.github/workflows/release_build.yml
+++ b/.github/workflows/release_build.yml
@@ -50,7 +50,7 @@ jobs:
           overwrite: true    
           tag: ${{ github.ref }}
           asset_name: choosenim-manylinux2014
-          file: ${{ runner.workspace }}/choosenim/bin/choosenim*   
+          file: ${{ runner.workspace }}/choosenim/bin/choosenim
 
   # ----------------------------------------------------------------------------
   build-win32:

--- a/.github/workflows/release_build.yml
+++ b/.github/workflows/release_build.yml
@@ -25,7 +25,7 @@ jobs:
           CHOOSENIM_DIR=`pwd`
           # checking out and compiling nim last stable from git tag
           mkdir -p nimDir
-          STABLE_NIM=`wget -qO- http://nim-lang.org/channels/stable | xargs`
+          STABLE_NIM=`curl -sSL http://nim-lang.org/channels/stable | xargs`
           git clone --depth 1 --branch v$STABLE_NIM https://github.com/nim-lang/Nim.git nimDir
           cd nimDir
           sh build_all.sh

--- a/.github/workflows/release_build.yml
+++ b/.github/workflows/release_build.yml
@@ -41,6 +41,14 @@ jobs:
           cd $CHOOSENIM_DIR
           nimble install -y
           nimble build
+      - name: Upload binaries to release
+        uses: svenstaro/upload-release-action@v2
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          overwrite: true    
+          tag: ${{ github.ref }}
+          asset_name: choosenim-manylinux2014
+          file: bin/choosenim*   
 
   # ----------------------------------------------------------------------------
   build-win32:
@@ -52,6 +60,15 @@ jobs:
         run: |
           nimble install -y
           nimble build
+          
+      - name: Upload binaries to release
+        uses: svenstaro/upload-release-action@v2
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          overwrite: true    
+          tag: ${{ github.ref }}
+          asset_name: choosenim-windows
+          file: bin/choosenim*     
 
   # ----------------------------------------------------------------------------
   build-macos:
@@ -63,3 +80,11 @@ jobs:
         run: |
           nimble install -y
           nimble build
+      - name: Upload binaries to release
+        uses: svenstaro/upload-release-action@v2
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          overwrite: true    
+          tag: ${{ github.ref }}
+          asset_name: choosenim-macos
+          file: bin/choosenim*      

--- a/.github/workflows/release_build.yml
+++ b/.github/workflows/release_build.yml
@@ -24,7 +24,6 @@ jobs:
       image: quay.io/pypa/manylinux2014_x86_64
     steps:
       - uses: actions/checkout@v2
-        # - uses: iffy/install-nim@v4.0.1
       - name: Build binary
         run: |
           CHOOSENIM_DIR=`pwd`

--- a/.github/workflows/release_build.yml
+++ b/.github/workflows/release_build.yml
@@ -24,9 +24,22 @@ jobs:
       image: quay.io/pypa/manylinux2014_x86_64
     steps:
       - uses: actions/checkout@v2
-      - uses: iffy/install-nim@v4.0.1
+      # - uses: iffy/install-nim@v4.0.1
       - name: Build binary
         run: |
+          CHOOSENIM_DIR=`pwd`
+        # checking out and compiling nim version-1-6 from git
+          mkdir -p nimDir
+          git clone -n https://github.com/nim-lang/Nim.git nimDir
+          cd nimDir
+          git checkout version-1-6
+          sh build_all.sh
+          bin/nim c koch
+          ./koch boot -d:release
+          ./koch tools
+          PATH=$PATH:`pwd`/bin
+        # compile choosenim
+          cd $CHOOSENIM_DIR
           nimble install -y
           nimble build
 

--- a/.github/workflows/release_build.yml
+++ b/.github/workflows/release_build.yml
@@ -48,7 +48,7 @@ jobs:
           overwrite: true    
           tag: ${{ github.ref }}
           asset_name: choosenim-manylinux2014
-          file: bin/choosenim*   
+          file: ${{ runner.workspace }}/bin/choosenim*   
 
   # ----------------------------------------------------------------------------
   build-win32:
@@ -68,7 +68,7 @@ jobs:
           overwrite: true    
           tag: ${{ github.ref }}
           asset_name: choosenim-windows
-          file: bin/choosenim*     
+          file: ${{ runner.workspace }}/bin/choosenim*     
 
   # ----------------------------------------------------------------------------
   build-macos:
@@ -87,4 +87,4 @@ jobs:
           overwrite: true    
           tag: ${{ github.ref }}
           asset_name: choosenim-macos
-          file: bin/choosenim*      
+          file: ${{ runner.workspace }}/bin/choosenim*      

--- a/.github/workflows/release_build.yml
+++ b/.github/workflows/release_build.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Build binary
         run: |
           CHOOSENIM_DIR=`pwd`
-        # checking out and compiling nim version-1-6 from git
+          # checking out and compiling nim version-1-6 from git
           mkdir -p nimDir
           git clone -n https://github.com/nim-lang/Nim.git nimDir
           cd nimDir
@@ -37,7 +37,7 @@ jobs:
           ./koch boot -d:release
           ./koch tools
           PATH=$PATH:`pwd`/bin
-        # compile choosenim
+          # compile choosenim
           cd $CHOOSENIM_DIR
           nimble install -y
           nimble build

--- a/.github/workflows/release_build.yml
+++ b/.github/workflows/release_build.yml
@@ -24,7 +24,7 @@ jobs:
       image: quay.io/pypa/manylinux2014_x86_64
     steps:
       - uses: actions/checkout@v2
-      # - uses: iffy/install-nim@v4.0.1
+        # - uses: iffy/install-nim@v4.0.1
       - name: Build binary
         run: |
           CHOOSENIM_DIR=`pwd`

--- a/.github/workflows/release_build.yml
+++ b/.github/workflows/release_build.yml
@@ -1,23 +1,19 @@
-# This workflow will upload a Python Package using Twine when a release is created
-# For more information see: https://help.github.com/en/actions/language-and-framework-guides/using-python-with-github-actions#publishing-to-package-registries
-
-# This workflow uses actions that are not certified by GitHub.
-# They are provided by a third-party and are governed by
-# separate terms of service, privacy policy, and support
-# documentation.
-
+# This workflow will automatically upload a binary artifact when a release/tag  is created
 name: Build and upload binary
 
 on:  
+  # allow to build manually 
   workflow_dispatch:
+  # build automatically when pushing a tag 
   push:
-    paths:
-      - 'choosenim.nimble'
     branches:
-      - main
+      - "!*"
+    tags:
+      - "v*"
 
 jobs:
- # ----------------------------------------------------------------------------
+  # ----------------------------------------------------------------------------
+  # this will checkout and build nim stable from gh repository on manylinux2014 / CentOS 7 
   build-linux:
     runs-on: ubuntu-latest
     container:
@@ -27,11 +23,11 @@ jobs:
       - name: Build binary
         run: |
           CHOOSENIM_DIR=`pwd`
-          # checking out and compiling nim version-1-6 from git
+          # checking out and compiling nim last stable from git tag
           mkdir -p nimDir
-          git clone -n https://github.com/nim-lang/Nim.git nimDir
+          STABLE_NIM=`wget -qO- http://nim-lang.org/channels/stable | xargs`
+          git clone --depth 1 --branch v$STABLE_NIM https://github.com/nim-lang/Nim.git nimDir
           cd nimDir
-          git checkout version-1-6
           sh build_all.sh
           bin/nim c koch
           ./koch boot -d:release
@@ -43,7 +39,7 @@ jobs:
           nimble build
           ls bin/*
           
-      - name: Upload binaries to release
+      - name: Upload binaries to release/tag
         uses: svenstaro/upload-release-action@v2
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
@@ -53,6 +49,7 @@ jobs:
           file: ${{ runner.workspace }}/choosenim/bin/choosenim
 
   # ----------------------------------------------------------------------------
+  # this uses choosenim by itself - you may need to build manually if you break choosenim
   build-win32:
     runs-on: windows-latest
     steps:
@@ -64,7 +61,7 @@ jobs:
           nimble build
           dir bin/*
           
-      - name: Upload binaries to release
+      - name: Upload binaries to release/tag
         uses: svenstaro/upload-release-action@v2
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
@@ -74,6 +71,7 @@ jobs:
           file: ${{ runner.workspace }}/choosenim/bin/choosenim.exe     
 
   # ----------------------------------------------------------------------------
+  # this uses choosenim by itself - you may need to build manually if you break choosenim
   build-macos:
     runs-on: macos-latest
     steps:
@@ -85,7 +83,7 @@ jobs:
           nimble build
           ls bin/*
           
-      - name: Upload binaries to release
+      - name: Upload binaries to release/tag
         uses: svenstaro/upload-release-action@v2
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release_build.yml
+++ b/.github/workflows/release_build.yml
@@ -63,6 +63,8 @@ jobs:
         run: |
           nimble install -y
           nimble build
+          dir
+          dir bin/choosenim.exe
           
       - name: Upload binaries to release
         uses: svenstaro/upload-release-action@v2
@@ -71,7 +73,7 @@ jobs:
           overwrite: true    
           tag: ${{ github.ref }}
           asset_name: choosenim-windows
-          file: bin/choosenim*     
+          file: ${{ runner.workspace }}/bin/choosenim.exe     
 
   # ----------------------------------------------------------------------------
   build-macos:
@@ -83,6 +85,9 @@ jobs:
         run: |
           nimble install -y
           nimble build
+          ls
+          ls bin
+          
       - name: Upload binaries to release
         uses: svenstaro/upload-release-action@v2
         with:
@@ -90,4 +95,4 @@ jobs:
           overwrite: true    
           tag: ${{ github.ref }}
           asset_name: choosenim-macos
-          file: bin/choosenim*      
+          file: ${{ runner.workspace }}/bin/choosenim      

--- a/.github/workflows/release_build.yml
+++ b/.github/workflows/release_build.yml
@@ -26,6 +26,9 @@ jobs:
       - uses: actions/checkout@v2
       - name: Build binary
         run: |
+          echo `pwd`
+          echo ${{ runner.workspace }}
+          exit -1
           CHOOSENIM_DIR=`pwd`
           # checking out and compiling nim version-1-6 from git
           mkdir -p nimDir
@@ -48,7 +51,7 @@ jobs:
           overwrite: true    
           tag: ${{ github.ref }}
           asset_name: choosenim-manylinux2014
-          file: ${{ runner.workspace }}/bin/choosenim*   
+          file: bin/choosenim*   
 
   # ----------------------------------------------------------------------------
   build-win32:
@@ -68,7 +71,7 @@ jobs:
           overwrite: true    
           tag: ${{ github.ref }}
           asset_name: choosenim-windows
-          file: ${{ runner.workspace }}/bin/choosenim*     
+          file: bin/choosenim*     
 
   # ----------------------------------------------------------------------------
   build-macos:
@@ -87,4 +90,4 @@ jobs:
           overwrite: true    
           tag: ${{ github.ref }}
           asset_name: choosenim-macos
-          file: ${{ runner.workspace }}/bin/choosenim*      
+          file: bin/choosenim*      


### PR DESCRIPTION
This workflow would automatically build and upload binaries for windows, linux and macos when tags are created. It may be triggered manually and would overwrite existing binaries.
On linux, it would use manylinux2014, so the binary would probably be compatible for RHEL 7 and other older and newer distributions.

Note: For windows, this would currently just upload the .exe and not the .bat /.zip file. Couldn't find the sources for those.

I only tested the manual trigger - not sure if upload on create tag would do everything correct.
You may delete this if you currently have some other solution :)