### PR TITLE
Initial working patch to build arm64 Nim binaries on M1 macs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 nimcache
 bin/choosenim
 src/choosenimpkg/proxyexe
+src/choosenimpkg/proxyexe-amd64
+src/choosenimpkg/proxyexe-arm64
 *.exe
 
 tests/nimcache

--- a/src/choosenimpkg/switcher.nim
+++ b/src/choosenimpkg/switcher.nim
@@ -12,6 +12,8 @@ proc compileProxyexe() =
   var cmd =
     when defined(windows):
       "cmd /C \"cd ../../ && nimble c"
+    elif defined(macosx):
+      "cd ../../ && nimble c --passC:'-arch arm64 -arch x86_64' --passL:'-arch arm64 -arch x86_64'"
     else:
       "cd ../../ && nimble c"
   when defined(release):

--- a/src/choosenimpkg/utils.nim
+++ b/src/choosenimpkg/utils.nim
@@ -30,21 +30,31 @@ proc parseVersion*(versionStr: string): Version =
 
   result = newVersion(versionStr)
 
+proc isRosetta*(): bool =
+  let res = execCmdEx("sysctl -in sysctl.proc_translated")
+  if res.exitCode == 0:
+    return res.output.strip() == "1"
+  return false
+
 proc doCmdRaw*(cmd: string) =
+  var command = cmd
   # To keep output in sequence
   stdout.flushFile()
   stderr.flushFile()
 
-  displayDebug("Executing", cmd)
+  if defined(macosx) and isRosetta():
+    command = "arch -arm64 " & command
+
+  displayDebug("Executing", command)
   displayDebug("Work Dir", getCurrentDir())
-  let (output, exitCode) = execCmdEx(cmd)
+  let (output, exitCode) = execCmdEx(command)
   displayDebug("Finished", "with exit code " & $exitCode)
   displayDebug("Output", output)
 
   if exitCode != QuitSuccess:
     raise newException(ChooseNimError,
         "Execution failed with exit code $1\nCommand: $2\nOutput: $3" %
-        [$exitCode, cmd, output])
+        [$exitCode, command, output])
 
 proc extract*(path: string, extractDir: string) =
   display("Extracting", path.extractFilename(), priority = HighPriority)

--- a/src/choosenimpkg/utils.nim
+++ b/src/choosenimpkg/utils.nim
@@ -198,7 +198,9 @@ proc getNightliesUrl*(parsedContents: JsonNode, arch: int): (string, string) =
             if "x" & $arch in aname:
               result = (url, tagName)
           else:
-            result = (url, tagName)
+            # when choosenim become arm64, isRosetta will be false, so, we have to guard that hostCPU is amd64 to use nightlies
+            if not isRosetta() and hostCPU == "amd64":
+              result = (url, tagName)
         if result[0].len != 0:
           break
     if result[0].len != 0:

--- a/src/choosenimpkg/utils.nim
+++ b/src/choosenimpkg/utils.nim
@@ -30,7 +30,7 @@ proc parseVersion*(versionStr: string): Version =
 
   result = newVersion(versionStr)
 
-proc isRosetta(): bool =
+proc isRosetta*(): bool =
   let res = execCmdEx("sysctl -in sysctl.proc_translated")
   if res.exitCode == 0:
     return res.output.strip() == "1"

--- a/src/choosenimpkg/utils.nim
+++ b/src/choosenimpkg/utils.nim
@@ -30,7 +30,7 @@ proc parseVersion*(versionStr: string): Version =
 
   result = newVersion(versionStr)
 
-proc isRosetta*(): bool =
+proc isRosetta(): bool =
   let res = execCmdEx("sysctl -in sysctl.proc_translated")
   if res.exitCode == 0:
     return res.output.strip() == "1"


### PR DESCRIPTION
The patch is quite simple.

choosenim use `proxyexe` that is statically compiled and statically read and is embedded in choosenim like this:

```nim
static: compileProxyexe()

const
  proxyExe = staticRead("proxyexe".addFileExt(ExeExt))
```

Instead of statically compiled `proxyexe`, I patched the `compileProxyexe` proc to compile `proxyexe` on user machine with embedded source code and previously compiled Nim like this:

```nim
const proxyExeSources = {
  "src" / "choosenimpkg" / "proxyexe.nim": staticRead("./proxyexe.nim"),
  "src" / "choosenimpkg" / "proxyexe.nims": staticRead("./proxyexe.nims"),
  "src" / "choosenimpkg" / "common.nim": staticRead("./common.nim"),
  "src" / "choosenimpkg" / "cliparams.nim": staticRead("./cliparams.nim"),
  "choosenim.nimble": staticRead("../../choosenim.nimble")
}.toTable()
```

I mean I embedded source codes required by `proxyexe` on choosenim binary. Then, I compiled them with previously compiled arm64 `nim` and `nimble` binaries ( choosenim compile nim first, then write proxy ).

Yeah, this is the main trick. And also on M1 macs with rosetta, I appended `arch -arm64` flags on most commands to run as arm process like this:

```nim
if defined(macosx) and isRosetta():
  command = "arch -arm64 " & command
```

You can mark this PR as draft. On my mac, it works fine. How about others?