### PR TITLE
Add documentation to help mac users

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -49,6 +49,18 @@ curl https://nim-lang.org/choosenim/init.sh -sSf | sh
 wget -qO - https://nim-lang.org/choosenim/init.sh | sh
 ```
 
+**For Macos Apple Silicon M1 & M2 CPUs **
+You need to have ``xcode-select`` and ``rossetta`` installed.
+install xcode-select
+```bash
+xcode-select --install
+```
+
+install rosetta
+```bash
+softwareupdate --install-rosetta
+```
+
 **Optional:** You can specify the initial version you would like the `init.sh`
               script to install by specifying the ``CHOOSENIM_CHOOSE_VERSION``
               environment variable.


### PR DESCRIPTION
Mac users need to install rosetta and xcode
both of the following need to be installed
```
xcode-select --install
softwareupdate --install-rosetta
```
otherwise new users will be faced with
```
choosenim-init: Downloading choosenim-0.8.4_macosx_amd64
sh: line 77: /var/folders/md/61b29s79495glw9mcnyhmbjr0000gn/T//choosenim-0.8.4_macosx_amd64: Bad CPU type in executable
```