### PR TITLE
Fix a PATH hijacking issue

### DIFF
--- a/scripts/choosenim-unix-init.sh
+++ b/scripts/choosenim-unix-init.sh
@@ -86,7 +86,7 @@ install() {
   say "You must now ensure that the Nimble bin dir is in your PATH."
   if [ "$platform" != "windows_amd64" ]; then
     say "Place the following line in the ~/.profile or ~/.bashrc file."
-    say "    export PATH=$nimbleBinDir:\$PATH"
+    say "    export PATH=\$PATH:$nimbleBinDir"
     case "${SHELL:=sh}" in
       *fish*)
       say "Running fish shell?"


### PR DESCRIPTION
Currently, the Unix installer encourages an unsafe action that can result in hijacking of the PATH variable. By setting the writable nimble directory as the first search location over standard locations like /bin and /usr/bin, an attacker can hijack PATH searches. Instead of prepending to the path, the new entry should be appended.