### PR TITLE
devel and version-2-0 channels now use csources_v2

### DIFF
--- a/src/choosenimpkg/builder.nim
+++ b/src/choosenimpkg/builder.nim
@@ -105,7 +105,7 @@ proc setPermissions() =
                           fpGroupRead, fpGroupExec,
                           fpOthersRead, fpOthersExec}
       )
-      display("Info", "Settbuilding rwxr-xr-x permissions: " & path, Message, LowPriority)
+      display("Info", "Setting rwxr-xr-x permissions: " & path, Message, LowPriority)
 
 proc build*(extractDir: string, version: Version, params: CliParams) =
   # Report telemetry.

--- a/src/choosenimpkg/builder.nim
+++ b/src/choosenimpkg/builder.nim
@@ -30,7 +30,7 @@ proc buildCompiler(version: Version, params: CliParams) =
     display("Warning:", "Building from latest C sources. They may not be " &
                         "compatible with the Nim version you have chosen to " &
                         "install.", Warning, HighPriority)
-    let path = downloadCSources(params)
+    let path = downloadCSources(version, params)
     let extractDir = getCurrentDir() / "csources"
     extract(path, extractDir)
 
@@ -105,7 +105,7 @@ proc setPermissions() =
                           fpGroupRead, fpGroupExec,
                           fpOthersRead, fpOthersExec}
       )
-      display("Info", "Setting rwxr-xr-x permissions: " & path, Message, LowPriority)
+      display("Info", "Settbuilding rwxr-xr-x permissions: " & path, Message, LowPriority)
 
 proc build*(extractDir: string, version: Version, params: CliParams) =
   # Report telemetry.

--- a/src/choosenimpkg/download.nim
+++ b/src/choosenimpkg/download.nim
@@ -316,11 +316,19 @@ proc download*(version: Version, params: CliParams): string =
     raise newException(ChooseNimError, "Version $1 does not exist." %
                        $version)
 
-proc downloadCSources*(params: CliParams): string =
+template useCSourcesV2(version: Version): bool =
+  $version in ["#head", "#devel", "#version-2-0"]
+
+proc downloadCSources*(version: Version, params: CliParams): string =
+  let csourcesAdaptedUrl =
+    if useCSourcesV2(version):
+      csourcesUrl & "_v2"
+    else:
+      csourcesUrl
   let
-    commit = getLatestCommit(csourcesUrl, "master")
+    commit = getLatestCommit(csourcesAdaptedUrl, "master")
     archive = if commit.len != 0: commit else: "master"
-    csourcesArchiveUrl = $(parseUri(csourcesUrl) / (dlArchive % archive))
+    csourcesArchiveUrl = $(parseUri(csourcesAdaptedUrl) / (dlArchive % archive))
 
   var outputPath: string
   if not needsDownload(params, csourcesArchiveUrl, outputPath):


### PR DESCRIPTION
Tested locally, it installs [csources_v2](https://github.com/nim-lang/csources_v2)

```nim
import src/choosenimpkg/[download, cliparams]
import nimblepkg/[version]

echo downloadCSources(newVersion("#version-2-0"), newCliParams(false))
```
ref https://forum.nim-lang.org/t/9746