### PR TITLE
Updated readme to address potential issue with MacOs

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -78,6 +78,14 @@ wget -qO - https://nim-lang.org/choosenim/init.sh | sh
               script to install by specifying the ``CHOOSENIM_CHOOSE_VERSION``
               environment variable.
 
+**MacOs Note** If `choosenim` has been installed successfully, and you're still not able to use Nim or any of the tooling (ex: `nim --v`) follow these steps in your terminal:
+- modify or create the `~/.zshrc` file with this line: `nano ~/.zshrc`
+- add the following line to setup the PATH correctly: `export PATH="$HOME/.nimble/bin:$PATH"`
+- make sure the current terminal session picks up the changes with this line: `source ~/.zshrc`
+- now validate everything works properly with: `nim --v`
+
+By creating a `.zshrc` file and adding the path to `~/.nimble/bin`, you're ensuring that zsh (terminal) knows where to look for your Nim executables and other tooling every time it starts up.
+
 ## How choosenim works
 
 Similar to the likes of ``rustup`` and ``pyenv``, ``choosenim`` is a

--- a/readme.md
+++ b/readme.md
@@ -78,14 +78,14 @@ wget -qO - https://nim-lang.org/choosenim/init.sh | sh
               script to install by specifying the ``CHOOSENIM_CHOOSE_VERSION``
               environment variable.
 
-**MacOs Note** If `choosenim` has been installed successfully, and you're still not able to use Nim or any of the tooling (ex: `nim --v`) follow these steps in your terminal:
-- modify or create the `~/.zshrc` file with this line: `nano ~/.zshrc`
+**PATH setup** If `choosenim` has been installed successfully, and you're still not able to use Nim or any of the tooling (ex: `nim --v`) follow these steps in your terminal:
+- MacOs: modify or create the `~/.zshenv` file with your preferred editor, e.g. `nano ~/.zshenv`
+- Linux: modify or create file `~/.bash_profile`, e.g. `nano ~/.bash_profile`
 - add the following line to setup the PATH correctly: `export PATH="$HOME/.nimble/bin:$PATH"`
-- make sure the current terminal session picks up the changes with this line: `source ~/.zshrc`
+- make sure the current terminal session picks up the changes with this line: `source ~/.zshenv` or `source ~/.bash_profile`
 - now validate everything works properly with: `nim --v`
 
-By creating a `.zshrc` file and adding the path to `~/.nimble/bin`, you're ensuring that zsh (terminal) knows where to look for your Nim executables and other tooling every time it starts up.
-
+By creating a `.zshenv` or `.bash_profile` file and adding the path to `~/.nimble/bin`, you're ensuring that your shell (terminal) knows where to look for your Nim executables and other tooling every time it starts up.
 ## How choosenim works
 
 Similar to the likes of ``rustup`` and ``pyenv``, ``choosenim`` is a


### PR DESCRIPTION
I banged my head against the wall for a couple of hours trying to get nim/choosenim/etc to work on my mac- I clearly saw `~/.nimble/bin` in my path via `echo $path` but it wouldn't work. Upon further investigation, apparently I didn't have a .zshrc file in my home directory and needed to add the path there.

This was on a clean installation of mac.

It may or may not be common so I figured it's best to add notes to the README.