### PR TITLE
add new repo location

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,3 +1,9 @@
+# Important!
+choosenim development has been moved to an official Nim repo: [nim-lang/choosenim](https://github.com/nim-lang/choosenim)
+
+Please make pull requests in the new repo. Thank you.
+
+
 # choosenim
 
 choosenim installs the [Nim programming language](https://nim-lang.org) from


### PR DESCRIPTION
Add an important update to let people know where the current [choosenim](https://github.com/nim-lang/choosenim) repo is located. When I search google, this is the only repo that shows up and not the official Nim one.

Didn't know if there was a specific reason this repo wasn't deprecated. 